### PR TITLE
Add --endpoint-url support for S3-compatible storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # s3lfs
 
-A Python-based version control system for large assets using Amazon S3. This system is designed to work like Git LFS but utilizes S3 for better bandwidth and scalability. It supports file tracking, parallel operations, and encryption.
+A Python-based version control system for large assets using Amazon S3 and S3-compatible storage. This system is designed to work like Git LFS but utilizes S3 for better bandwidth and scalability. It supports file tracking, parallel operations, encryption, and any S3-compatible backend (MinIO, Cloudflare R2, Backblaze B2, Wasabi, DigitalOcean Spaces, etc.).
 
 ## Features
 
@@ -243,6 +243,24 @@ export AWS_ACCESS_KEY_ID=your_access_key
 export AWS_SECRET_ACCESS_KEY=your_secret_key
 export AWS_DEFAULT_REGION=us-east-1
 ```
+
+### S3-Compatible Storage
+Use the `--endpoint-url` flag to connect to any S3-compatible storage provider:
+```sh
+# MinIO
+s3lfs init my-bucket my-project --endpoint-url http://localhost:9000
+
+# Cloudflare R2
+s3lfs init my-bucket my-project --endpoint-url https://<account-id>.r2.cloudflarestorage.com
+
+# Backblaze B2
+s3lfs init my-bucket my-project --endpoint-url https://s3.us-west-004.backblazeb2.com
+
+# Wasabi
+s3lfs init my-bucket my-project --endpoint-url https://s3.wasabisys.com
+```
+
+The endpoint URL is stored in the manifest, so subsequent commands pick it up automatically — no need to pass `--endpoint-url` on every invocation. You can override it per-command if needed.
 
 ### Public Buckets
 For public S3 buckets, use the `--no-sign-request` flag:

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -86,7 +86,12 @@ def cli():
 @click.option(
     "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
 )
-def init(bucket, prefix, no_sign_request, use_acceleration):
+@click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage (e.g. MinIO, R2, Wasabi)",
+)
+def init(bucket, prefix, no_sign_request, use_acceleration, endpoint_url):
     """Initialize S3LFS with a bucket and repo prefix"""
     # Find git root
     git_root = find_git_root()
@@ -106,6 +111,7 @@ def init(bucket, prefix, no_sign_request, use_acceleration):
             repo_prefix=prefix,
             no_sign_request=no_sign_request,
             use_acceleration=use_acceleration,
+            endpoint_url=endpoint_url,
         )
         s3lfs.initialize_repo()
         print(f"✅ Repository initialized with bucket '{bucket}' and prefix '{prefix}'")
@@ -121,6 +127,11 @@ def init(bucket, prefix, no_sign_request, use_acceleration):
     "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
 )
 @click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+@click.option(
     "--verbose", is_flag=True, help="Show detailed progress and upload information"
 )
 @click.option(
@@ -133,7 +144,13 @@ def init(bucket, prefix, no_sign_request, use_acceleration):
     help="Enable parallelism metrics collection",
 )
 def track(
-    path, no_sign_request, use_acceleration, verbose, modified, enable_metrics_flag
+    path,
+    no_sign_request,
+    use_acceleration,
+    endpoint_url,
+    verbose,
+    modified,
+    enable_metrics_flag,
 ):
     """Track files, directories, or globs. Use --modified to track only changed files."""
     # Enable metrics if requested
@@ -153,6 +170,7 @@ def track(
         no_sign_request=no_sign_request,
         manifest_file=str(manifest_path),
         use_acceleration=use_acceleration,
+        endpoint_url=endpoint_url,
     )
 
     if modified:
@@ -176,6 +194,11 @@ def track(
     "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
 )
 @click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+@click.option(
     "--verbose",
     is_flag=True,
     help="Show detailed progress and download size information",
@@ -188,7 +211,13 @@ def track(
     help="Enable parallelism metrics collection",
 )
 def checkout(
-    path, no_sign_request, use_acceleration, verbose, all, enable_metrics_flag
+    path,
+    no_sign_request,
+    use_acceleration,
+    endpoint_url,
+    verbose,
+    all,
+    enable_metrics_flag,
 ):
     """Checkout files, directories, or globs. Use --all to checkout all tracked files."""
     # Enable metrics if requested
@@ -208,6 +237,7 @@ def checkout(
         no_sign_request=no_sign_request,
         manifest_file=str(manifest_path),
         use_acceleration=use_acceleration,
+        endpoint_url=endpoint_url,
     )
 
     if all:
@@ -234,7 +264,14 @@ def checkout(
     help="Show detailed information including file sizes and hashes",
 )
 @click.option("--all", is_flag=True, help="List all tracked files from manifest")
-def ls(path, no_sign_request, use_acceleration, verbose, all, git_finder_func=None):
+@click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+def ls(
+    path, no_sign_request, use_acceleration, verbose, all, endpoint_url, git_finder_func=None
+):
     """List tracked files, directories, or globs. If no path is provided, lists all tracked files."""
     # Common setup: find git root, check manifest, resolve path
     # Note: git_finder_func is for testing purposes only
@@ -274,6 +311,7 @@ def ls(path, no_sign_request, use_acceleration, verbose, all, git_finder_func=No
         no_sign_request=no_sign_request,
         manifest_file=str(manifest_path),
         use_acceleration=use_acceleration,
+        endpoint_url=endpoint_url,
     )
 
     if all or not manifest_key:
@@ -299,7 +337,12 @@ def ls(path, no_sign_request, use_acceleration, verbose, all, git_finder_func=No
 @click.option(
     "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
 )
-def remove(path, purge_from_s3, no_sign_request, use_acceleration):
+@click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+def remove(path, purge_from_s3, no_sign_request, use_acceleration, endpoint_url):
     """Remove files or directories from tracking. Supports glob patterns."""
     # Common setup: find git root, check manifest, resolve path
     git_root, manifest_path, path_resolver, manifest_key = _setup_s3lfs_command(
@@ -310,6 +353,7 @@ def remove(path, purge_from_s3, no_sign_request, use_acceleration):
         no_sign_request=no_sign_request,
         manifest_file=str(manifest_path),
         use_acceleration=use_acceleration,
+        endpoint_url=endpoint_url,
     )
 
     # Check if this is a single file (no glob, not a directory)
@@ -333,7 +377,12 @@ def remove(path, purge_from_s3, no_sign_request, use_acceleration):
 @click.option(
     "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
 )
-def cleanup(force, no_sign_request, use_acceleration):
+@click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+def cleanup(force, no_sign_request, use_acceleration, endpoint_url):
     """Clean up unreferenced files from S3."""
     # Find git root
     git_root = find_git_root()
@@ -350,6 +399,7 @@ def cleanup(force, no_sign_request, use_acceleration):
         no_sign_request=no_sign_request,
         manifest_file=str(manifest_path),
         use_acceleration=use_acceleration,
+        endpoint_url=endpoint_url,
     )
     versioner.cleanup_s3(force=force)
 

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -270,7 +270,13 @@ def checkout(
     help="Custom S3 endpoint URL for S3-compatible storage",
 )
 def ls(
-    path, no_sign_request, use_acceleration, verbose, all, endpoint_url, git_finder_func=None
+    path,
+    no_sign_request,
+    use_acceleration,
+    verbose,
+    all,
+    endpoint_url,
+    git_finder_func=None,
 ):
     """List tracked files, directories, or globs. If no path is provided, lists all tracked files."""
     # Common setup: find git root, check manifest, resolve path

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -97,6 +97,7 @@ class S3LFS:
         chunk_size=DEFAULT_CHUNK_SIZE,
         s3_factory=None,
         use_acceleration=False,
+        endpoint_url=None,
     ):
         """
         :param bucket_name: Name of the S3 bucket (can be stored in manifest)
@@ -108,25 +109,32 @@ class S3LFS:
         :param chunk_size: Size of chunks for multipart uploads (default: 5 GB)
         :param s3_factory: Custom S3 client factory function (for testing)
         :param use_acceleration: If True, enable S3 Transfer Acceleration
+        :param endpoint_url: Custom S3 endpoint URL for S3-compatible storage (e.g. MinIO, R2, Wasabi)
         """
         self.chunk_size = chunk_size
         self.use_acceleration = use_acceleration
+        self.endpoint_url = endpoint_url
 
         def default_s3_factory(no_sign_request):
             """Default S3 client factory with proper boto3 usage."""
+            kwargs = {}
+            if self.endpoint_url:
+                kwargs["endpoint_url"] = self.endpoint_url
             if no_sign_request:
                 if self.use_acceleration:
                     raise RuntimeError(ERROR_MESSAGES["acceleration_not_supported"])
                 config = Config(signature_version=UNSIGNED)
-                return boto3.client("s3", config=config)
+                return boto3.client("s3", config=config, **kwargs)
             else:
                 if self.use_acceleration:
                     # Use transfer acceleration endpoint
                     return boto3.client(
-                        "s3", config=Config(s3={"use_accelerate_endpoint": True})
+                        "s3",
+                        config=Config(s3={"use_accelerate_endpoint": True}),
+                        **kwargs,
                     )
                 else:
-                    return boto3.client("s3")
+                    return boto3.client("s3", **kwargs)
 
         self.s3_factory = s3_factory if s3_factory is not None else default_s3_factory
 
@@ -180,6 +188,13 @@ class S3LFS:
                 self.manifest["repo_prefix"] = repo_prefix
             else:
                 self.repo_prefix = self.manifest.get("repo_prefix", "s3lfs")
+
+            # Load endpoint_url from manifest if not provided as parameter
+            if self.endpoint_url:
+                self.manifest["endpoint_url"] = self.endpoint_url
+            else:
+                self.endpoint_url = self.manifest.get("endpoint_url")
+
             self.save_manifest()
 
         self.encryption = encryption
@@ -260,6 +275,8 @@ class S3LFS:
                 self.manifest["bucket_name"] = str(self.bucket_name)  # type: ignore
             if self.repo_prefix is not None:
                 self.manifest["repo_prefix"] = str(self.repo_prefix)  # type: ignore
+            if self.endpoint_url is not None:
+                self.manifest["endpoint_url"] = str(self.endpoint_url)  # type: ignore
             self.save_manifest()
 
         # Update .gitignore to exclude cache files
@@ -268,6 +285,8 @@ class S3LFS:
         print("✅ Successfully initialized S3LFS with:")
         print(f"   Bucket Name: {self.bucket_name}")
         print(f"   Repo Prefix: {self.repo_prefix}")
+        if self.endpoint_url:
+            print(f"   Endpoint URL: {self.endpoint_url}")
         print(f"Manifest file saved as {self.manifest_file.name}")
 
     def _update_gitignore(self):

--- a/test_endpoint_url.py
+++ b/test_endpoint_url.py
@@ -1,4 +1,3 @@
-import json
 import os
 import tempfile
 import unittest
@@ -119,7 +118,7 @@ class TestEndpointUrl(unittest.TestCase):
             mock_client = Mock()
             mock_boto3_client.return_value = mock_client
 
-            s3lfs = S3LFS(
+            S3LFS(
                 bucket_name="test-bucket",
                 repo_prefix="test-prefix",
                 endpoint_url="http://localhost:9000",
@@ -157,9 +156,7 @@ class TestEndpointUrl(unittest.TestCase):
             s3lfs._get_s3_client()
 
             call_args = mock_boto3_client.call_args
-            self.assertEqual(
-                call_args[1]["endpoint_url"], "http://minio.internal:9000"
-            )
+            self.assertEqual(call_args[1]["endpoint_url"], "http://minio.internal:9000")
 
     def test_endpoint_url_parameter_overrides_manifest(self):
         """Test that endpoint_url parameter takes precedence over manifest value."""
@@ -188,9 +185,7 @@ class TestEndpointUrl(unittest.TestCase):
             # Manifest should be updated with the new value
             with open(self.manifest_file, "r") as f:
                 saved_manifest = yaml.safe_load(f)
-            self.assertEqual(
-                saved_manifest["endpoint_url"], "http://new-endpoint:9000"
-            )
+            self.assertEqual(saved_manifest["endpoint_url"], "http://new-endpoint:9000")
 
     def test_endpoint_url_stored_by_initialize_repo(self):
         """Test that initialize_repo persists endpoint_url to manifest."""
@@ -309,9 +304,7 @@ class TestEndpointUrlCli(unittest.TestCase):
             mock_client = Mock()
             mock_boto3_client.return_value = mock_client
             mock_client.upload_fileobj = Mock()
-            mock_client.head_object = Mock(
-                side_effect=Exception("not found")
-            )
+            mock_client.head_object = Mock(side_effect=Exception("not found"))
 
             result = runner.invoke(
                 cli,

--- a/test_endpoint_url.py
+++ b/test_endpoint_url.py
@@ -1,0 +1,421 @@
+import json
+import os
+import tempfile
+import unittest
+from unittest.mock import Mock, patch
+
+import yaml
+
+from s3lfs.core import S3LFS
+
+
+class TestEndpointUrl(unittest.TestCase):
+    """Tests for custom S3 endpoint URL functionality."""
+
+    def setUp(self):
+        """Set up test environment."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+
+        # Create a git repository
+        os.makedirs(".git")
+
+        # Create manifest file
+        self.manifest_file = ".s3_manifest.yaml"
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "files": {},
+        }
+        with open(self.manifest_file, "w") as f:
+            yaml.safe_dump(manifest, f)
+
+    def tearDown(self):
+        """Clean up test environment."""
+        os.chdir(self.original_cwd)
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_endpoint_url_passed_to_boto3_client(self):
+        """Test that endpoint_url is passed through to boto3.client."""
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                repo_prefix="test-prefix",
+                endpoint_url="http://localhost:9000",
+            )
+
+            s3lfs._get_s3_client()
+
+            mock_boto3_client.assert_called_once()
+            call_args = mock_boto3_client.call_args
+            self.assertEqual(call_args[1]["endpoint_url"], "http://localhost:9000")
+
+    def test_endpoint_url_with_unsigned_requests(self):
+        """Test that endpoint_url works with --no-sign-request."""
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                repo_prefix="test-prefix",
+                endpoint_url="http://localhost:9000",
+                no_sign_request=True,
+            )
+
+            s3lfs._get_s3_client()
+
+            mock_boto3_client.assert_called_once()
+            call_args = mock_boto3_client.call_args
+            self.assertEqual(call_args[1]["endpoint_url"], "http://localhost:9000")
+
+    def test_endpoint_url_with_acceleration(self):
+        """Test that endpoint_url works alongside transfer acceleration."""
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                repo_prefix="test-prefix",
+                endpoint_url="http://localhost:9000",
+                use_acceleration=True,
+            )
+
+            s3lfs._get_s3_client()
+
+            mock_boto3_client.assert_called_once()
+            call_args = mock_boto3_client.call_args
+            self.assertEqual(call_args[1]["endpoint_url"], "http://localhost:9000")
+            config = call_args[1]["config"]
+            self.assertTrue(config.s3["use_accelerate_endpoint"])
+
+    def test_no_endpoint_url_by_default(self):
+        """Test that endpoint_url is not passed when not specified."""
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                repo_prefix="test-prefix",
+            )
+
+            s3lfs._get_s3_client()
+
+            mock_boto3_client.assert_called_once()
+            call_args = mock_boto3_client.call_args
+            self.assertNotIn("endpoint_url", call_args[1])
+
+    def test_endpoint_url_stored_in_manifest(self):
+        """Test that endpoint_url is persisted to the manifest."""
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                repo_prefix="test-prefix",
+                endpoint_url="http://localhost:9000",
+            )
+
+            # Read manifest and check endpoint_url is stored
+            with open(self.manifest_file, "r") as f:
+                manifest = yaml.safe_load(f)
+
+            self.assertEqual(manifest["endpoint_url"], "http://localhost:9000")
+
+    def test_endpoint_url_loaded_from_manifest(self):
+        """Test that endpoint_url is loaded from manifest when not passed as parameter."""
+        # Write manifest with endpoint_url
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "endpoint_url": "http://minio.internal:9000",
+            "files": {},
+        }
+        with open(self.manifest_file, "w") as f:
+            yaml.safe_dump(manifest, f)
+
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                repo_prefix="test-prefix",
+            )
+
+            self.assertEqual(s3lfs.endpoint_url, "http://minio.internal:9000")
+
+            s3lfs._get_s3_client()
+
+            call_args = mock_boto3_client.call_args
+            self.assertEqual(
+                call_args[1]["endpoint_url"], "http://minio.internal:9000"
+            )
+
+    def test_endpoint_url_parameter_overrides_manifest(self):
+        """Test that endpoint_url parameter takes precedence over manifest value."""
+        # Write manifest with one endpoint_url
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "endpoint_url": "http://old-endpoint:9000",
+            "files": {},
+        }
+        with open(self.manifest_file, "w") as f:
+            yaml.safe_dump(manifest, f)
+
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                repo_prefix="test-prefix",
+                endpoint_url="http://new-endpoint:9000",
+            )
+
+            self.assertEqual(s3lfs.endpoint_url, "http://new-endpoint:9000")
+
+            # Manifest should be updated with the new value
+            with open(self.manifest_file, "r") as f:
+                saved_manifest = yaml.safe_load(f)
+            self.assertEqual(
+                saved_manifest["endpoint_url"], "http://new-endpoint:9000"
+            )
+
+    def test_endpoint_url_stored_by_initialize_repo(self):
+        """Test that initialize_repo persists endpoint_url to manifest."""
+        # Start with a clean manifest (no endpoint_url)
+        os.remove(self.manifest_file)
+
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                repo_prefix="test-prefix",
+                endpoint_url="https://r2.cloudflarestorage.com",
+            )
+            s3lfs.initialize_repo()
+
+            with open(self.manifest_file, "r") as f:
+                manifest = yaml.safe_load(f)
+
+            self.assertEqual(
+                manifest["endpoint_url"], "https://r2.cloudflarestorage.com"
+            )
+
+    def test_endpoint_url_not_stored_when_none(self):
+        """Test that endpoint_url key is not added to manifest when not set."""
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                repo_prefix="test-prefix",
+            )
+            s3lfs.initialize_repo()
+
+            with open(self.manifest_file, "r") as f:
+                manifest = yaml.safe_load(f)
+
+            self.assertNotIn("endpoint_url", manifest)
+
+
+class TestEndpointUrlCli(unittest.TestCase):
+    """Tests for endpoint URL CLI integration."""
+
+    def setUp(self):
+        """Set up test environment."""
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+
+        # Create a git repository
+        os.makedirs(".git")
+
+        # Create manifest file
+        self.manifest_file = ".s3_manifest.yaml"
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "files": {},
+        }
+        with open(self.manifest_file, "w") as f:
+            yaml.safe_dump(manifest, f)
+
+    def tearDown(self):
+        """Clean up test environment."""
+        os.chdir(self.original_cwd)
+        import shutil
+
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_init_accepts_endpoint_url(self):
+        """Test that the init command accepts --endpoint-url."""
+        from click.testing import CliRunner
+
+        from s3lfs.cli import cli
+
+        os.remove(self.manifest_file)
+
+        runner = CliRunner()
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "init",
+                    "my-bucket",
+                    "my-prefix",
+                    "--endpoint-url",
+                    "http://localhost:9000",
+                ],
+            )
+
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertIn("Repository initialized", result.output)
+
+            # Verify manifest has endpoint_url
+            with open(self.manifest_file, "r") as f:
+                manifest = yaml.safe_load(f)
+            self.assertEqual(manifest["endpoint_url"], "http://localhost:9000")
+
+    def test_track_accepts_endpoint_url(self):
+        """Test that the track command accepts --endpoint-url."""
+        from click.testing import CliRunner
+
+        from s3lfs.cli import cli
+
+        # Create a file to track
+        with open("test_file.txt", "w") as f:
+            f.write("hello")
+
+        runner = CliRunner()
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+            mock_client.upload_fileobj = Mock()
+            mock_client.head_object = Mock(
+                side_effect=Exception("not found")
+            )
+
+            result = runner.invoke(
+                cli,
+                [
+                    "track",
+                    "test_file.txt",
+                    "--endpoint-url",
+                    "http://localhost:9000",
+                ],
+            )
+
+            # Should not fail due to unrecognized option
+            self.assertNotIn("no such option", result.output.lower())
+
+    def test_checkout_accepts_endpoint_url(self):
+        """Test that the checkout command accepts --endpoint-url."""
+        from click.testing import CliRunner
+
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "checkout",
+                    "--all",
+                    "--endpoint-url",
+                    "http://localhost:9000",
+                ],
+            )
+
+            self.assertNotIn("no such option", result.output.lower())
+
+    def test_ls_accepts_endpoint_url(self):
+        """Test that the ls command accepts --endpoint-url."""
+        from click.testing import CliRunner
+
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                ["ls", "--endpoint-url", "http://localhost:9000"],
+            )
+
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+
+    def test_remove_accepts_endpoint_url(self):
+        """Test that the remove command accepts --endpoint-url."""
+        from click.testing import CliRunner
+
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+
+            result = runner.invoke(
+                cli,
+                [
+                    "remove",
+                    "somefile.txt",
+                    "--endpoint-url",
+                    "http://localhost:9000",
+                ],
+            )
+
+            # May fail because file doesn't exist, but should not fail
+            # due to unrecognized option
+            self.assertNotIn("no such option", result.output.lower())
+
+    def test_cleanup_accepts_endpoint_url(self):
+        """Test that the cleanup command accepts --endpoint-url."""
+        from click.testing import CliRunner
+
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("boto3.client") as mock_boto3_client:
+            mock_client = Mock()
+            mock_boto3_client.return_value = mock_client
+            mock_client.list_objects_v2 = Mock(return_value={"Contents": []})
+
+            result = runner.invoke(
+                cli,
+                [
+                    "cleanup",
+                    "--force",
+                    "--endpoint-url",
+                    "http://localhost:9000",
+                ],
+            )
+
+            self.assertNotIn("no such option", result.output.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `--endpoint-url` option to all CLI commands (`init`, `track`, `checkout`, `ls`, `remove`, `cleanup`)
- Passes custom endpoint URL through to `boto3.client()` for S3-compatible storage providers (MinIO, Cloudflare R2, Backblaze B2, Wasabi, DigitalOcean Spaces, etc.)
- Stores `endpoint_url` in the manifest so it only needs to be specified once during `init`; subsequent commands pick it up automatically
- CLI flag overrides manifest value when both are present

## Test plan

- [x] 15 new tests in `test_endpoint_url.py` covering:
  - boto3 client receives endpoint_url for signed, unsigned, and acceleration modes
  - endpoint_url not passed when unset (no regression for AWS users)
  - manifest persistence and loading
  - parameter override of manifest value
  - `initialize_repo` persistence
  - CLI acceptance for all 6 commands
- [x] All 157 existing CLI/integration tests still pass

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)