### PR TITLE
Add .s3lfsconfig for per-repo configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,10 +311,24 @@ s3lfs init my-bucket my-project --endpoint-url https://s3.us-west-004.backblazeb
 s3lfs init my-bucket my-project --endpoint-url https://s3.wasabisys.com
 ```
 
-The endpoint URL is stored in the manifest, so subsequent commands pick it up automatically — no need to pass `--endpoint-url` on every invocation. You can override it per-command if needed.
+The endpoint URL is stored in the manifest, so subsequent commands pick it up automatically. You can override it per-command if needed.
+
+### Per-Repo Config File
+Create a `.s3lfsconfig` file at the git root to set defaults for the whole team:
+```yaml
+# .s3lfsconfig - commit this to version control
+no_sign_request: true
+use_acceleration: false
+```
+
+When `.s3lfsconfig` exists, its values are used as defaults for all commands. CLI flags still override config values - for example, `s3lfs track --no-sign-request` always uses unsigned requests regardless of the config.
+
+**Supported keys**:
+- `no_sign_request`: Use unsigned S3 requests (default: `false`)
+- `use_acceleration`: Enable S3 Transfer Acceleration (default: `false`)
 
 ### Public Buckets
-For public S3 buckets, use the `--no-sign-request` flag:
+For public S3 buckets, use the `--no-sign-request` flag or set it in `.s3lfsconfig`:
 ```sh
 s3lfs init public-bucket my-project --no-sign-request
 s3lfs checkout --all --no-sign-request

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -11,7 +11,9 @@ from s3lfs.path_resolver import PathResolver
 from s3lfs.utils import find_git_root
 
 
-def _make_s3lfs(git_root, manifest_path, no_sign_request=False, use_acceleration=False, **extra):
+def _make_s3lfs(
+    git_root, manifest_path, no_sign_request=False, use_acceleration=False, **extra
+):
     """Create an S3LFS instance with .s3lfsconfig defaults applied.
 
     CLI flags (when True) override config-file values.
@@ -185,7 +187,8 @@ def track(
         manifest_key = None
 
     s3lfs = _make_s3lfs(
-        git_root, manifest_path,
+        git_root,
+        manifest_path,
         no_sign_request=no_sign_request,
         use_acceleration=use_acceleration,
         endpoint_url=endpoint_url,
@@ -252,7 +255,8 @@ def checkout(
         manifest_key = None
 
     s3lfs = _make_s3lfs(
-        git_root, manifest_path,
+        git_root,
+        manifest_path,
         no_sign_request=no_sign_request,
         use_acceleration=use_acceleration,
         endpoint_url=endpoint_url,
@@ -332,7 +336,8 @@ def ls(
         relative_cwd = Path(".")
 
     s3lfs = _make_s3lfs(
-        git_root, manifest_path,
+        git_root,
+        manifest_path,
         no_sign_request=no_sign_request,
         use_acceleration=use_acceleration,
         endpoint_url=endpoint_url,
@@ -374,7 +379,8 @@ def remove(path, purge_from_s3, no_sign_request, use_acceleration, endpoint_url)
     )
 
     versioner = _make_s3lfs(
-        git_root, manifest_path,
+        git_root,
+        manifest_path,
         no_sign_request=no_sign_request,
         use_acceleration=use_acceleration,
         endpoint_url=endpoint_url,
@@ -420,7 +426,8 @@ def cleanup(force, no_sign_request, use_acceleration, endpoint_url):
         raise click.Abort()
 
     versioner = _make_s3lfs(
-        git_root, manifest_path,
+        git_root,
+        manifest_path,
         no_sign_request=no_sign_request,
         use_acceleration=use_acceleration,
         endpoint_url=endpoint_url,

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -5,9 +5,27 @@ import click
 import yaml
 
 from s3lfs import metrics
+from s3lfs.config import load_config
 from s3lfs.core import S3LFS
 from s3lfs.path_resolver import PathResolver
 from s3lfs.utils import find_git_root
+
+
+def _make_s3lfs(git_root, manifest_path, no_sign_request=False, use_acceleration=False, **extra):
+    """Create an S3LFS instance with .s3lfsconfig defaults applied.
+
+    CLI flags (when True) override config-file values.
+    """
+    config = load_config(git_root)
+    # CLI True overrides config; CLI False falls back to config
+    effective_no_sign = no_sign_request or config.get("no_sign_request", False)
+    effective_accel = use_acceleration or config.get("use_acceleration", False)
+    return S3LFS(
+        no_sign_request=effective_no_sign,
+        manifest_file=str(manifest_path),
+        use_acceleration=effective_accel,
+        **extra,
+    )
 
 
 def _setup_s3lfs_command(cli_path=None, require_manifest=True):
@@ -166,9 +184,9 @@ def track(
         git_root, manifest_path, path_resolver = _setup_s3lfs_command()
         manifest_key = None
 
-    s3lfs = S3LFS(
+    s3lfs = _make_s3lfs(
+        git_root, manifest_path,
         no_sign_request=no_sign_request,
-        manifest_file=str(manifest_path),
         use_acceleration=use_acceleration,
         endpoint_url=endpoint_url,
     )
@@ -233,9 +251,9 @@ def checkout(
         git_root, manifest_path, path_resolver = _setup_s3lfs_command()
         manifest_key = None
 
-    s3lfs = S3LFS(
+    s3lfs = _make_s3lfs(
+        git_root, manifest_path,
         no_sign_request=no_sign_request,
-        manifest_file=str(manifest_path),
         use_acceleration=use_acceleration,
         endpoint_url=endpoint_url,
     )
@@ -313,9 +331,9 @@ def ls(
     except ValueError:
         relative_cwd = Path(".")
 
-    s3lfs = S3LFS(
+    s3lfs = _make_s3lfs(
+        git_root, manifest_path,
         no_sign_request=no_sign_request,
-        manifest_file=str(manifest_path),
         use_acceleration=use_acceleration,
         endpoint_url=endpoint_url,
     )
@@ -355,9 +373,9 @@ def remove(path, purge_from_s3, no_sign_request, use_acceleration, endpoint_url)
         cli_path=path
     )
 
-    versioner = S3LFS(
+    versioner = _make_s3lfs(
+        git_root, manifest_path,
         no_sign_request=no_sign_request,
-        manifest_file=str(manifest_path),
         use_acceleration=use_acceleration,
         endpoint_url=endpoint_url,
     )
@@ -401,9 +419,9 @@ def cleanup(force, no_sign_request, use_acceleration, endpoint_url):
         click.echo("Error: S3LFS not initialized. Run 's3lfs init' first.")
         raise click.Abort()
 
-    versioner = S3LFS(
+    versioner = _make_s3lfs(
+        git_root, manifest_path,
         no_sign_request=no_sign_request,
-        manifest_file=str(manifest_path),
         use_acceleration=use_acceleration,
         endpoint_url=endpoint_url,
     )

--- a/s3lfs/config.py
+++ b/s3lfs/config.py
@@ -1,0 +1,58 @@
+"""
+Load per-repo configuration from .s3lfsconfig (YAML).
+
+The config file lives at the git repository root and is intended to be
+committed so every team member gets the same defaults.  CLI flags
+always override values from the config file.
+"""
+
+from pathlib import Path
+
+import yaml
+
+CONFIG_FILENAME = ".s3lfsconfig"
+
+# Keys recognised in .s3lfsconfig and their default values.
+DEFAULTS = {
+    "no_sign_request": False,
+    "use_acceleration": False,
+}
+
+
+def find_config(git_root):
+    """Return the Path to .s3lfsconfig if it exists, else None."""
+    path = Path(git_root) / CONFIG_FILENAME
+    return path if path.is_file() else None
+
+
+def load_config(git_root):
+    """Load .s3lfsconfig from *git_root* and return a dict.
+
+    Missing file → empty dict.  Unknown keys are silently ignored so the
+    file stays forward-compatible.
+    """
+    path = find_config(git_root)
+    if path is None:
+        return {}
+    with open(path, "r") as f:
+        data = yaml.safe_load(f) or {}
+    # Only keep recognised keys
+    return {k: data[k] for k in DEFAULTS if k in data}
+
+
+def apply_config(config, cli_kwargs):
+    """Merge *config* (from file) with *cli_kwargs* (from CLI flags).
+
+    CLI flags take precedence.  For boolean flags Click always supplies a
+    value (True/False), so we treat ``False`` the same as "not supplied"
+    — only an explicit ``True`` from the CLI overrides the config.
+
+    Returns a new dict suitable for passing to ``S3LFS()``.
+    """
+    merged = dict(DEFAULTS)
+    merged.update(config)
+    for key in DEFAULTS:
+        cli_val = cli_kwargs.get(key)
+        if cli_val:
+            merged[key] = cli_val
+    return merged

--- a/test_config.py
+++ b/test_config.py
@@ -1,0 +1,295 @@
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import yaml
+from click.testing import CliRunner
+
+from s3lfs.config import CONFIG_FILENAME, apply_config, find_config, load_config
+
+
+class TestFindConfig(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_returns_path_when_exists(self):
+        config_path = Path(self.temp_dir) / CONFIG_FILENAME
+        config_path.write_text("no_sign_request: true\n")
+        result = find_config(self.temp_dir)
+        self.assertEqual(result, config_path)
+
+    def test_returns_none_when_missing(self):
+        result = find_config(self.temp_dir)
+        self.assertIsNone(result)
+
+
+class TestLoadConfig(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_loads_recognized_keys(self):
+        config_path = Path(self.temp_dir) / CONFIG_FILENAME
+        config_path.write_text(
+            "no_sign_request: true\nuse_acceleration: true\n"
+        )
+        config = load_config(self.temp_dir)
+        self.assertEqual(config, {"no_sign_request": True, "use_acceleration": True})
+
+    def test_ignores_unknown_keys(self):
+        config_path = Path(self.temp_dir) / CONFIG_FILENAME
+        config_path.write_text(
+            "no_sign_request: true\nfuture_option: some_value\n"
+        )
+        config = load_config(self.temp_dir)
+        self.assertNotIn("future_option", config)
+        self.assertTrue(config["no_sign_request"])
+
+    def test_returns_empty_when_missing(self):
+        config = load_config(self.temp_dir)
+        self.assertEqual(config, {})
+
+    def test_returns_empty_for_empty_file(self):
+        config_path = Path(self.temp_dir) / CONFIG_FILENAME
+        config_path.write_text("")
+        config = load_config(self.temp_dir)
+        self.assertEqual(config, {})
+
+    def test_partial_config(self):
+        config_path = Path(self.temp_dir) / CONFIG_FILENAME
+        config_path.write_text("use_acceleration: true\n")
+        config = load_config(self.temp_dir)
+        self.assertEqual(config, {"use_acceleration": True})
+        self.assertNotIn("no_sign_request", config)
+
+
+class TestApplyConfig(unittest.TestCase):
+    def test_cli_true_overrides_config_false(self):
+        config = {"no_sign_request": False, "use_acceleration": False}
+        cli_kwargs = {"no_sign_request": True, "use_acceleration": False}
+        merged = apply_config(config, cli_kwargs)
+        self.assertTrue(merged["no_sign_request"])
+        self.assertFalse(merged["use_acceleration"])
+
+    def test_config_true_used_when_cli_false(self):
+        config = {"no_sign_request": True, "use_acceleration": True}
+        cli_kwargs = {"no_sign_request": False, "use_acceleration": False}
+        merged = apply_config(config, cli_kwargs)
+        self.assertTrue(merged["no_sign_request"])
+        self.assertTrue(merged["use_acceleration"])
+
+    def test_defaults_when_no_config_no_cli(self):
+        config = {}
+        cli_kwargs = {"no_sign_request": False, "use_acceleration": False}
+        merged = apply_config(config, cli_kwargs)
+        self.assertFalse(merged["no_sign_request"])
+        self.assertFalse(merged["use_acceleration"])
+
+    def test_empty_cli_kwargs(self):
+        config = {"no_sign_request": True}
+        merged = apply_config(config, {})
+        self.assertTrue(merged["no_sign_request"])
+
+
+class TestConfigCLIIntegration(unittest.TestCase):
+    """Test that .s3lfsconfig is picked up by CLI commands."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "files": {},
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_ls_uses_config_no_sign_request(self):
+        """ls command picks up no_sign_request from .s3lfsconfig."""
+        # Write config
+        Path(CONFIG_FILENAME).write_text("no_sign_request: true\n")
+
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("s3lfs.cli.S3LFS") as mock_cls:
+            mock_instance = Mock()
+            mock_cls.return_value = mock_instance
+            mock_instance.manifest = {
+                "bucket_name": "test-bucket",
+                "repo_prefix": "test-prefix",
+                "files": {},
+            }
+            mock_instance.list_all_files = Mock()
+
+            result = runner.invoke(cli, ["ls"])
+
+            # S3LFS should have been called with no_sign_request=True
+            call_kwargs = mock_cls.call_args[1]
+            self.assertTrue(call_kwargs["no_sign_request"])
+
+    def test_ls_cli_flag_overrides_config(self):
+        """CLI --no-sign-request overrides config value of false."""
+        # Config says false
+        Path(CONFIG_FILENAME).write_text("no_sign_request: false\n")
+
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("s3lfs.cli.S3LFS") as mock_cls:
+            mock_instance = Mock()
+            mock_cls.return_value = mock_instance
+            mock_instance.manifest = {
+                "bucket_name": "test-bucket",
+                "repo_prefix": "test-prefix",
+                "files": {},
+            }
+            mock_instance.list_all_files = Mock()
+
+            result = runner.invoke(cli, ["ls", "--no-sign-request"])
+
+            call_kwargs = mock_cls.call_args[1]
+            self.assertTrue(call_kwargs["no_sign_request"])
+
+    def test_track_uses_config_use_acceleration(self):
+        """track command picks up use_acceleration from .s3lfsconfig."""
+        Path(CONFIG_FILENAME).write_text("use_acceleration: true\n")
+
+        # Create a file to track
+        Path("testfile.txt").write_text("hello")
+
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("s3lfs.cli.S3LFS") as mock_cls:
+            mock_instance = Mock()
+            mock_cls.return_value = mock_instance
+            mock_instance.manifest = {
+                "bucket_name": "test-bucket",
+                "repo_prefix": "test-prefix",
+                "files": {},
+            }
+            mock_instance.track = Mock()
+
+            result = runner.invoke(cli, ["track", "testfile.txt"])
+
+            call_kwargs = mock_cls.call_args[1]
+            self.assertTrue(call_kwargs["use_acceleration"])
+
+    def test_commands_work_without_config_file(self):
+        """Commands work fine when .s3lfsconfig doesn't exist."""
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("s3lfs.cli.S3LFS") as mock_cls:
+            mock_instance = Mock()
+            mock_cls.return_value = mock_instance
+            mock_instance.manifest = {
+                "bucket_name": "test-bucket",
+                "repo_prefix": "test-prefix",
+                "files": {},
+            }
+            mock_instance.list_all_files = Mock()
+
+            result = runner.invoke(cli, ["ls"])
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+
+            call_kwargs = mock_cls.call_args[1]
+            self.assertFalse(call_kwargs["no_sign_request"])
+            self.assertFalse(call_kwargs["use_acceleration"])
+
+    def test_checkout_uses_config(self):
+        """checkout command picks up config."""
+        Path(CONFIG_FILENAME).write_text(
+            "no_sign_request: true\nuse_acceleration: false\n"
+        )
+
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("s3lfs.cli.S3LFS") as mock_cls:
+            mock_instance = Mock()
+            mock_cls.return_value = mock_instance
+            mock_instance.manifest = {
+                "bucket_name": "test-bucket",
+                "repo_prefix": "test-prefix",
+                "files": {},
+            }
+            mock_instance.parallel_download_all = Mock()
+
+            result = runner.invoke(cli, ["checkout", "--all"])
+
+            call_kwargs = mock_cls.call_args[1]
+            self.assertTrue(call_kwargs["no_sign_request"])
+            self.assertFalse(call_kwargs["use_acceleration"])
+
+    def test_cleanup_uses_config(self):
+        """cleanup command picks up config."""
+        Path(CONFIG_FILENAME).write_text("no_sign_request: true\n")
+
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("s3lfs.cli.S3LFS") as mock_cls:
+            mock_instance = Mock()
+            mock_cls.return_value = mock_instance
+            mock_instance.manifest = {
+                "bucket_name": "test-bucket",
+                "repo_prefix": "test-prefix",
+                "files": {},
+            }
+            mock_instance.cleanup_s3 = Mock()
+
+            result = runner.invoke(cli, ["cleanup", "--force"])
+
+            call_kwargs = mock_cls.call_args[1]
+            self.assertTrue(call_kwargs["no_sign_request"])
+
+    def test_remove_uses_config(self):
+        """remove command picks up config."""
+        Path(CONFIG_FILENAME).write_text("no_sign_request: true\n")
+
+        # Add a file to the manifest so remove has something to work with
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "files": {"somefile.txt": "abc123"},
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+        from s3lfs.cli import cli
+
+        runner = CliRunner()
+        with patch("s3lfs.cli.S3LFS") as mock_cls:
+            mock_instance = Mock()
+            mock_cls.return_value = mock_instance
+            mock_instance.manifest = manifest
+            mock_instance.remove_file = Mock()
+            mock_instance.remove_subtree = Mock()
+            mock_instance.path_resolver = Mock()
+
+            result = runner.invoke(cli, ["remove", "somefile.txt"])
+
+            call_kwargs = mock_cls.call_args[1]
+            self.assertTrue(call_kwargs["no_sign_request"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_config.py
+++ b/test_config.py
@@ -38,17 +38,13 @@ class TestLoadConfig(unittest.TestCase):
 
     def test_loads_recognized_keys(self):
         config_path = Path(self.temp_dir) / CONFIG_FILENAME
-        config_path.write_text(
-            "no_sign_request: true\nuse_acceleration: true\n"
-        )
+        config_path.write_text("no_sign_request: true\nuse_acceleration: true\n")
         config = load_config(self.temp_dir)
         self.assertEqual(config, {"no_sign_request": True, "use_acceleration": True})
 
     def test_ignores_unknown_keys(self):
         config_path = Path(self.temp_dir) / CONFIG_FILENAME
-        config_path.write_text(
-            "no_sign_request: true\nfuture_option: some_value\n"
-        )
+        config_path.write_text("no_sign_request: true\nfuture_option: some_value\n")
         config = load_config(self.temp_dir)
         self.assertNotIn("future_option", config)
         self.assertTrue(config["no_sign_request"])
@@ -138,7 +134,7 @@ class TestConfigCLIIntegration(unittest.TestCase):
             }
             mock_instance.list_all_files = Mock()
 
-            result = runner.invoke(cli, ["ls"])
+            runner.invoke(cli, ["ls"])
 
             # S3LFS should have been called with no_sign_request=True
             call_kwargs = mock_cls.call_args[1]
@@ -162,7 +158,7 @@ class TestConfigCLIIntegration(unittest.TestCase):
             }
             mock_instance.list_all_files = Mock()
 
-            result = runner.invoke(cli, ["ls", "--no-sign-request"])
+            runner.invoke(cli, ["ls", "--no-sign-request"])
 
             call_kwargs = mock_cls.call_args[1]
             self.assertTrue(call_kwargs["no_sign_request"])
@@ -187,7 +183,7 @@ class TestConfigCLIIntegration(unittest.TestCase):
             }
             mock_instance.track = Mock()
 
-            result = runner.invoke(cli, ["track", "testfile.txt"])
+            runner.invoke(cli, ["track", "testfile.txt"])
 
             call_kwargs = mock_cls.call_args[1]
             self.assertTrue(call_kwargs["use_acceleration"])
@@ -233,7 +229,7 @@ class TestConfigCLIIntegration(unittest.TestCase):
             }
             mock_instance.parallel_download_all = Mock()
 
-            result = runner.invoke(cli, ["checkout", "--all"])
+            runner.invoke(cli, ["checkout", "--all"])
 
             call_kwargs = mock_cls.call_args[1]
             self.assertTrue(call_kwargs["no_sign_request"])
@@ -256,7 +252,7 @@ class TestConfigCLIIntegration(unittest.TestCase):
             }
             mock_instance.cleanup_s3 = Mock()
 
-            result = runner.invoke(cli, ["cleanup", "--force"])
+            runner.invoke(cli, ["cleanup", "--force"])
 
             call_kwargs = mock_cls.call_args[1]
             self.assertTrue(call_kwargs["no_sign_request"])
@@ -285,7 +281,7 @@ class TestConfigCLIIntegration(unittest.TestCase):
             mock_instance.remove_subtree = Mock()
             mock_instance.path_resolver = Mock()
 
-            result = runner.invoke(cli, ["remove", "somefile.txt"])
+            runner.invoke(cli, ["remove", "somefile.txt"])
 
             call_kwargs = mock_cls.call_args[1]
             self.assertTrue(call_kwargs["no_sign_request"])

--- a/test_config.py
+++ b/test_config.py
@@ -83,7 +83,7 @@ class TestApplyConfig(unittest.TestCase):
         self.assertTrue(merged["use_acceleration"])
 
     def test_defaults_when_no_config_no_cli(self):
-        config = {}
+        config: dict = {}
         cli_kwargs = {"no_sign_request": False, "use_acceleration": False}
         merged = apply_config(config, cli_kwargs)
         self.assertFalse(merged["no_sign_request"])


### PR DESCRIPTION
## Summary

- Adds `.s3lfsconfig` YAML file support at the git root for team-wide defaults
- Supported keys: `no_sign_request`, `use_acceleration`
- Config is loaded by all commands (`track`, `checkout`, `ls`, `remove`, `cleanup`)
- CLI flags always override config values (boolean `True` from CLI wins)
- Unknown keys are silently ignored for forward-compatibility
- Missing config file is a no-op (backwards compatible)
- New `s3lfs/config.py` module with `find_config`, `load_config`, `apply_config`
- New `_make_s3lfs` helper in CLI that merges config + CLI flags before constructing `S3LFS()`

## Test plan

- [x] 18 new tests in `test_config.py` covering:
  - `find_config`: exists/missing
  - `load_config`: full config, partial, unknown keys, empty file, missing file
  - `apply_config`: CLI override, config fallback, defaults
  - CLI integration: `ls`, `track`, `checkout`, `cleanup`, `remove` all pick up config
  - CLI flag overrides config value
  - Commands work without config file
- [x] All 106 existing CLI tests still pass

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)