### PR TITLE
Add s3lfs migrate-from-lfs to convert Git LFS repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,32 @@ s3lfs cleanup
 s3lfs cleanup --force                    # Clean up without confirmation
 ```
 
+### Migrate from Git LFS
+```sh
+s3lfs migrate-from-lfs <bucket-name> <repo-prefix>
+```
+**Description**: Converts a Git LFS repository to s3lfs in one step. Detects LFS-tracked patterns from `.gitattributes`, verifies files contain real content (not pointer files), initializes s3lfs, and uploads all files to S3.
+
+**Options**:
+- `--dry-run`: Preview what would be migrated without making changes
+- `--remove-lfs/--keep-lfs`: Remove LFS entries from `.gitattributes` after migration (default: keep)
+- `--no-sign-request`: Use unsigned S3 requests
+- `--use-acceleration`: Enable S3 Transfer Acceleration
+
+**Examples**:
+```sh
+# Preview migration
+s3lfs migrate-from-lfs my-bucket my-project --dry-run
+
+# Migrate and keep LFS entries (safe, reversible)
+s3lfs migrate-from-lfs my-bucket my-project
+
+# Migrate and remove LFS tracking
+s3lfs migrate-from-lfs my-bucket my-project --remove-lfs
+```
+
+**Prerequisites**: Run `git lfs pull` first to ensure all LFS files contain actual content (not pointer files). The command will error if any pointer files are detected.
+
 ## Git Workflow Integration
 
 ### 1. Initialize S3LFS

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -453,7 +453,7 @@ def _parse_lfs_patterns(git_root):
 
     Returns a list of glob patterns that have the 'filter=lfs' attribute.
     """
-    patterns = []
+    patterns: list = []
     gitattributes = Path(git_root) / ".gitattributes"
     if not gitattributes.exists():
         return patterns
@@ -475,8 +475,6 @@ def _find_lfs_files(git_root, patterns):
 
     Returns list of Path objects relative to git_root.
     """
-    import fnmatch
-
     git_root = Path(git_root)
     matched_files = []
 
@@ -484,7 +482,9 @@ def _find_lfs_files(git_root, patterns):
         # Use glob to find matching files
         if "**" in pattern or "*" in pattern or "?" in pattern:
             for match in git_root.glob(pattern):
-                if match.is_file() and not str(match.relative_to(git_root)).startswith(".git"):
+                if match.is_file() and not str(match.relative_to(git_root)).startswith(
+                    ".git"
+                ):
                     matched_files.append(match)
         else:
             # Exact path
@@ -509,13 +509,17 @@ def _find_lfs_files(git_root, patterns):
 @click.option(
     "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
 )
-@click.option("--dry-run", is_flag=True, help="Show what would be migrated without making changes")
+@click.option(
+    "--dry-run", is_flag=True, help="Show what would be migrated without making changes"
+)
 @click.option(
     "--remove-lfs/--keep-lfs",
     default=False,
     help="Remove LFS tracking from .gitattributes after migration (default: keep)",
 )
-def migrate_from_lfs(bucket, prefix, no_sign_request, use_acceleration, dry_run, remove_lfs):
+def migrate_from_lfs(
+    bucket, prefix, no_sign_request, use_acceleration, dry_run, remove_lfs
+):
     """Migrate a Git LFS repository to s3lfs.
 
     Detects LFS-tracked files from .gitattributes, verifies they contain
@@ -574,13 +578,17 @@ def migrate_from_lfs(bucket, prefix, no_sign_request, use_acceleration, dry_run,
     # Step 3: Check for un-smudged pointer files
     pointers = [f for f in lfs_files if _is_lfs_pointer(f)]
     if pointers:
-        click.echo(f"Error: {len(pointers)} file(s) are LFS pointer files (not actual content):")
+        click.echo(
+            f"Error: {len(pointers)} file(s) are LFS pointer files (not actual content):"
+        )
         for f in pointers[:10]:
             click.echo(f"  {f.relative_to(git_root)}")
         if len(pointers) > 10:
             click.echo(f"  ... and {len(pointers) - 10} more")
         click.echo()
-        click.echo("Run 'git lfs pull' to download the actual file content, then retry.")
+        click.echo(
+            "Run 'git lfs pull' to download the actual file content, then retry."
+        )
         raise click.Abort()
 
     if dry_run:
@@ -619,9 +627,13 @@ def migrate_from_lfs(bucket, prefix, no_sign_request, use_acceleration, dry_run,
     click.echo()
     click.echo("Next steps:")
     click.echo("  1. Review the changes: git diff")
-    click.echo("  2. Commit: git add .s3_manifest.yaml .gitignore .gitattributes && git commit -m 'Migrate from Git LFS to s3lfs'")
+    click.echo(
+        "  2. Commit: git add .s3_manifest.yaml .gitignore .gitattributes && git commit -m 'Migrate from Git LFS to s3lfs'"
+    )
     if not remove_lfs:
-        click.echo("  3. (Optional) Remove LFS: run again with --remove-lfs, or manually edit .gitattributes")
+        click.echo(
+            "  3. (Optional) Remove LFS: run again with --remove-lfs, or manually edit .gitattributes"
+        )
     click.echo("  4. (Optional) Uninstall Git LFS: git lfs uninstall")
 
 

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -438,6 +438,223 @@ def migrate(force):
     click.echo("  4. Update .gitignore if needed")
 
 
+def _is_lfs_pointer(file_path):
+    """Check if a file is a Git LFS pointer file (not actual content)."""
+    try:
+        with open(file_path, "rb") as f:
+            header = f.read(512)
+        return header.startswith(b"version https://git-lfs.github.com/spec/v1")
+    except (IOError, OSError):
+        return False
+
+
+def _parse_lfs_patterns(git_root):
+    """Parse .gitattributes for LFS-tracked patterns.
+
+    Returns a list of glob patterns that have the 'filter=lfs' attribute.
+    """
+    patterns = []
+    gitattributes = Path(git_root) / ".gitattributes"
+    if not gitattributes.exists():
+        return patterns
+
+    with open(gitattributes, "r") as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            # .gitattributes format: <pattern> <attr1> <attr2> ...
+            parts = line.split()
+            if len(parts) >= 2 and "filter=lfs" in parts:
+                patterns.append(parts[0])
+    return patterns
+
+
+def _find_lfs_files(git_root, patterns):
+    """Find all files matching LFS patterns that exist on disk.
+
+    Returns list of Path objects relative to git_root.
+    """
+    import fnmatch
+
+    git_root = Path(git_root)
+    matched_files = []
+
+    for pattern in patterns:
+        # Use glob to find matching files
+        if "**" in pattern or "*" in pattern or "?" in pattern:
+            for match in git_root.glob(pattern):
+                if match.is_file() and not str(match.relative_to(git_root)).startswith(".git"):
+                    matched_files.append(match)
+        else:
+            # Exact path
+            candidate = git_root / pattern
+            if candidate.is_file():
+                matched_files.append(candidate)
+
+    # Deduplicate
+    seen = set()
+    unique = []
+    for f in matched_files:
+        if f not in seen:
+            seen.add(f)
+            unique.append(f)
+    return unique
+
+
+@click.command("migrate-from-lfs")
+@click.argument("bucket", required=True)
+@click.argument("prefix", required=True)
+@click.option("--no-sign-request", is_flag=True, help="Use unsigned S3 requests")
+@click.option(
+    "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
+)
+@click.option("--dry-run", is_flag=True, help="Show what would be migrated without making changes")
+@click.option(
+    "--remove-lfs/--keep-lfs",
+    default=False,
+    help="Remove LFS tracking from .gitattributes after migration (default: keep)",
+)
+def migrate_from_lfs(bucket, prefix, no_sign_request, use_acceleration, dry_run, remove_lfs):
+    """Migrate a Git LFS repository to s3lfs.
+
+    Detects LFS-tracked files from .gitattributes, verifies they contain
+    real content (not pointer files), initializes s3lfs, and uploads all
+    files to S3.
+
+    Requires that LFS files have been fetched (run 'git lfs pull' first).
+    """
+    git_root = find_git_root()
+    if not git_root:
+        click.echo("Error: Not in a git repository")
+        raise click.Abort()
+
+    # Check if already initialized
+    manifest_path = get_manifest_path(git_root)
+    if manifest_path.exists():
+        click.echo("Error: s3lfs is already initialized in this repository.")
+        click.echo("Remove .s3_manifest.yaml first if you want to re-migrate.")
+        raise click.Abort()
+
+    # Step 1: Parse LFS patterns from .gitattributes
+    gitattributes_path = git_root / ".gitattributes"
+    if not gitattributes_path.exists():
+        click.echo("Error: No .gitattributes file found.")
+        click.echo("This repository doesn't appear to use Git LFS.")
+        raise click.Abort()
+
+    lfs_patterns = _parse_lfs_patterns(git_root)
+    if not lfs_patterns:
+        click.echo("Error: No Git LFS patterns found in .gitattributes.")
+        click.echo("Expected entries like: '*.bin filter=lfs diff=lfs merge=lfs -text'")
+        raise click.Abort()
+
+    click.echo(f"Found {len(lfs_patterns)} LFS pattern(s) in .gitattributes:")
+    for p in lfs_patterns:
+        click.echo(f"  {p}")
+    click.echo()
+
+    # Step 2: Find matching files
+    lfs_files = _find_lfs_files(git_root, lfs_patterns)
+    if not lfs_files:
+        click.echo("No files matching LFS patterns found on disk.")
+        click.echo("Nothing to migrate.")
+        return
+
+    click.echo(f"Found {len(lfs_files)} file(s) to migrate:")
+    total_size = 0
+    for f in lfs_files:
+        rel = f.relative_to(git_root)
+        size = f.stat().st_size
+        total_size += size
+        click.echo(f"  {rel} ({_human_size(size)})")
+    click.echo(f"  Total: {_human_size(total_size)}")
+    click.echo()
+
+    # Step 3: Check for un-smudged pointer files
+    pointers = [f for f in lfs_files if _is_lfs_pointer(f)]
+    if pointers:
+        click.echo(f"Error: {len(pointers)} file(s) are LFS pointer files (not actual content):")
+        for f in pointers[:10]:
+            click.echo(f"  {f.relative_to(git_root)}")
+        if len(pointers) > 10:
+            click.echo(f"  ... and {len(pointers) - 10} more")
+        click.echo()
+        click.echo("Run 'git lfs pull' to download the actual file content, then retry.")
+        raise click.Abort()
+
+    if dry_run:
+        click.echo("Dry run complete. No changes made.")
+        return
+
+    # Step 4: Initialize s3lfs
+    click.echo("Initializing s3lfs...")
+    try:
+        s3lfs_obj = S3LFS(
+            bucket_name=bucket,
+            repo_prefix=prefix,
+            no_sign_request=no_sign_request,
+            use_acceleration=use_acceleration,
+        )
+        s3lfs_obj.initialize_repo()
+    except Exception as e:
+        click.echo(f"Error initializing s3lfs: {e}")
+        raise click.Abort()
+    click.echo()
+
+    # Step 5: Track all LFS files
+    click.echo("Uploading files to S3...")
+    for lfs_pattern in lfs_patterns:
+        s3lfs_obj.track(lfs_pattern, silence=False, interleaved=True, use_cache=False)
+    click.echo()
+
+    # Step 6: Optionally remove LFS tracking
+    if remove_lfs:
+        click.echo("Removing LFS tracking from .gitattributes...")
+        _remove_lfs_from_gitattributes(gitattributes_path, lfs_patterns)
+        click.echo("  Updated .gitattributes")
+        click.echo()
+
+    click.echo("Migration complete!")
+    click.echo()
+    click.echo("Next steps:")
+    click.echo("  1. Review the changes: git diff")
+    click.echo("  2. Commit: git add .s3_manifest.yaml .gitignore .gitattributes && git commit -m 'Migrate from Git LFS to s3lfs'")
+    if not remove_lfs:
+        click.echo("  3. (Optional) Remove LFS: run again with --remove-lfs, or manually edit .gitattributes")
+    click.echo("  4. (Optional) Uninstall Git LFS: git lfs uninstall")
+
+
+def _human_size(size_bytes):
+    """Format a byte count as a human-readable string."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size_bytes < 1024:
+            return f"{size_bytes:.1f} {unit}"
+        size_bytes /= 1024
+    return f"{size_bytes:.1f} PB"
+
+
+def _remove_lfs_from_gitattributes(gitattributes_path, lfs_patterns):
+    """Remove LFS filter entries from .gitattributes.
+
+    Removes lines whose pattern matches one of the LFS patterns.
+    Leaves other lines intact.
+    """
+    lines = gitattributes_path.read_text().splitlines(keepends=True)
+    kept = []
+    for line in lines:
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            parts = stripped.split()
+            if len(parts) >= 2 and "filter=lfs" in parts and parts[0] in lfs_patterns:
+                continue  # Skip this LFS line
+        kept.append(line)
+
+    # Remove trailing blank lines
+    text = "".join(kept).rstrip("\n") + "\n" if kept else ""
+    gitattributes_path.write_text(text)
+
+
 cli.add_command(init)
 cli.add_command(track)
 cli.add_command(checkout)
@@ -445,6 +662,7 @@ cli.add_command(ls)
 cli.add_command(remove)
 cli.add_command(cleanup)
 cli.add_command(migrate)
+cli.add_command(migrate_from_lfs)
 
 
 def main():

--- a/test_migrate_from_lfs.py
+++ b/test_migrate_from_lfs.py
@@ -1,0 +1,321 @@
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import yaml
+from botocore.exceptions import ClientError
+from click.testing import CliRunner
+
+from s3lfs.cli import (
+    _find_lfs_files,
+    _is_lfs_pointer,
+    _parse_lfs_patterns,
+    _remove_lfs_from_gitattributes,
+    cli,
+)
+
+
+class TestIsLfsPointer(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_detects_pointer_file(self):
+        p = Path(self.temp_dir) / "pointer.bin"
+        p.write_text(
+            "version https://git-lfs.github.com/spec/v1\n"
+            "oid sha256:abc123\n"
+            "size 12345\n"
+        )
+        self.assertTrue(_is_lfs_pointer(p))
+
+    def test_real_content_not_detected(self):
+        p = Path(self.temp_dir) / "real.bin"
+        p.write_bytes(b"\x89PNG\r\n\x1a\nsome image data here")
+        self.assertFalse(_is_lfs_pointer(p))
+
+    def test_empty_file(self):
+        p = Path(self.temp_dir) / "empty"
+        p.write_bytes(b"")
+        self.assertFalse(_is_lfs_pointer(p))
+
+    def test_nonexistent_file(self):
+        self.assertFalse(_is_lfs_pointer(Path(self.temp_dir) / "nope"))
+
+
+class TestParseLfsPatterns(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_parses_standard_lfs_entries(self):
+        ga = Path(self.temp_dir) / ".gitattributes"
+        ga.write_text(
+            "*.bin filter=lfs diff=lfs merge=lfs -text\n"
+            "*.psd filter=lfs diff=lfs merge=lfs -text\n"
+            "# a comment\n"
+            "*.txt text\n"
+        )
+        patterns = _parse_lfs_patterns(self.temp_dir)
+        self.assertEqual(patterns, ["*.bin", "*.psd"])
+
+    def test_no_lfs_entries(self):
+        ga = Path(self.temp_dir) / ".gitattributes"
+        ga.write_text("*.txt text\n")
+        patterns = _parse_lfs_patterns(self.temp_dir)
+        self.assertEqual(patterns, [])
+
+    def test_no_gitattributes(self):
+        patterns = _parse_lfs_patterns(self.temp_dir)
+        self.assertEqual(patterns, [])
+
+    def test_empty_lines_and_comments(self):
+        ga = Path(self.temp_dir) / ".gitattributes"
+        ga.write_text("\n# comment\n\n*.dat filter=lfs diff=lfs -text\n\n")
+        patterns = _parse_lfs_patterns(self.temp_dir)
+        self.assertEqual(patterns, ["*.dat"])
+
+    def test_directory_pattern(self):
+        ga = Path(self.temp_dir) / ".gitattributes"
+        ga.write_text("data/**/*.bin filter=lfs diff=lfs merge=lfs -text\n")
+        patterns = _parse_lfs_patterns(self.temp_dir)
+        self.assertEqual(patterns, ["data/**/*.bin"])
+
+
+class TestFindLfsFiles(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.git_root = Path(self.temp_dir)
+        # Create some files
+        (self.git_root / "a.bin").write_bytes(b"binary a")
+        (self.git_root / "b.bin").write_bytes(b"binary b")
+        (self.git_root / "c.txt").write_text("text")
+        os.makedirs(self.git_root / "data")
+        (self.git_root / "data" / "d.bin").write_bytes(b"binary d")
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_finds_glob_matches(self):
+        files = _find_lfs_files(self.git_root, ["*.bin"])
+        names = {f.name for f in files}
+        self.assertIn("a.bin", names)
+        self.assertIn("b.bin", names)
+        self.assertNotIn("c.txt", names)
+
+    def test_recursive_glob(self):
+        files = _find_lfs_files(self.git_root, ["**/*.bin"])
+        names = {f.name for f in files}
+        self.assertIn("d.bin", names)
+
+    def test_no_matches(self):
+        files = _find_lfs_files(self.git_root, ["*.xyz"])
+        self.assertEqual(files, [])
+
+    def test_deduplicates(self):
+        files = _find_lfs_files(self.git_root, ["*.bin", "*.bin"])
+        names = [f.name for f in files]
+        self.assertEqual(len([n for n in names if n == "a.bin"]), 1)
+
+    def test_excludes_git_dir(self):
+        os.makedirs(self.git_root / ".git" / "lfs")
+        (self.git_root / ".git" / "lfs" / "test.bin").write_bytes(b"lfs obj")
+        files = _find_lfs_files(self.git_root, ["**/*.bin"])
+        for f in files:
+            self.assertFalse(
+                str(f.relative_to(self.git_root)).startswith(".git"),
+                f"Should exclude .git files: {f}",
+            )
+
+
+class TestRemoveLfsFromGitattributes(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.ga_path = Path(self.temp_dir) / ".gitattributes"
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_removes_lfs_lines(self):
+        self.ga_path.write_text(
+            "*.bin filter=lfs diff=lfs merge=lfs -text\n"
+            "*.txt text\n"
+        )
+        _remove_lfs_from_gitattributes(self.ga_path, ["*.bin"])
+        content = self.ga_path.read_text()
+        self.assertNotIn("filter=lfs", content)
+        self.assertIn("*.txt text", content)
+
+    def test_preserves_comments(self):
+        self.ga_path.write_text(
+            "# Important comment\n"
+            "*.bin filter=lfs diff=lfs -text\n"
+        )
+        _remove_lfs_from_gitattributes(self.ga_path, ["*.bin"])
+        content = self.ga_path.read_text()
+        self.assertIn("# Important comment", content)
+
+    def test_removes_multiple_patterns(self):
+        self.ga_path.write_text(
+            "*.bin filter=lfs diff=lfs -text\n"
+            "*.psd filter=lfs diff=lfs -text\n"
+            "*.txt text\n"
+        )
+        _remove_lfs_from_gitattributes(self.ga_path, ["*.bin", "*.psd"])
+        content = self.ga_path.read_text()
+        self.assertNotIn("*.bin", content)
+        self.assertNotIn("*.psd", content)
+        self.assertIn("*.txt", content)
+
+
+class TestMigrateFromLfsCommand(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_fails_without_gitattributes(self):
+        runner = CliRunner()
+        result = runner.invoke(cli, ["migrate-from-lfs", "bucket", "prefix"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("No .gitattributes", result.output)
+
+    def test_fails_without_lfs_patterns(self):
+        Path(".gitattributes").write_text("*.txt text\n")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["migrate-from-lfs", "bucket", "prefix"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("No Git LFS patterns", result.output)
+
+    def test_fails_if_already_initialized(self):
+        Path(".gitattributes").write_text("*.bin filter=lfs diff=lfs -text\n")
+        Path(".s3_manifest.yaml").write_text("bucket_name: x\n")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["migrate-from-lfs", "bucket", "prefix"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("already initialized", result.output)
+
+    def test_fails_on_pointer_files(self):
+        Path(".gitattributes").write_text("*.bin filter=lfs diff=lfs -text\n")
+        Path("data.bin").write_text(
+            "version https://git-lfs.github.com/spec/v1\n"
+            "oid sha256:abc\n"
+            "size 100\n"
+        )
+        runner = CliRunner()
+        result = runner.invoke(cli, ["migrate-from-lfs", "bucket", "prefix"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("pointer files", result.output)
+        self.assertIn("git lfs pull", result.output)
+
+    def test_no_matching_files(self):
+        Path(".gitattributes").write_text("*.bin filter=lfs diff=lfs -text\n")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["migrate-from-lfs", "bucket", "prefix"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("No files matching", result.output)
+
+    def test_dry_run(self):
+        Path(".gitattributes").write_text("*.bin filter=lfs diff=lfs -text\n")
+        Path("data.bin").write_bytes(b"real binary content here")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["migrate-from-lfs", "bucket", "prefix", "--dry-run"]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("Dry run complete", result.output)
+        self.assertIn("data.bin", result.output)
+        # Should not have created manifest
+        self.assertFalse(Path(".s3_manifest.yaml").exists())
+
+    def test_successful_migration(self):
+        Path(".gitattributes").write_text("*.bin filter=lfs diff=lfs -text\n")
+        Path("data.bin").write_bytes(b"real binary content")
+
+        runner = CliRunner()
+        with patch("boto3.client") as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.return_value = mock_client
+            mock_client.upload_fileobj = Mock()
+            mock_client.head_object = Mock(
+                side_effect=ClientError(
+                    {"Error": {"Code": "404", "Message": "Not Found"}},
+                    "HeadObject",
+                )
+            )
+
+            result = runner.invoke(
+                cli, ["migrate-from-lfs", "my-bucket", "my-prefix"]
+            )
+
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertIn("Migration complete", result.output)
+            # Manifest should exist
+            self.assertTrue(Path(".s3_manifest.yaml").exists())
+            with open(".s3_manifest.yaml") as f:
+                manifest = yaml.safe_load(f)
+            self.assertEqual(manifest["bucket_name"], "my-bucket")
+            self.assertEqual(manifest["repo_prefix"], "my-prefix")
+
+    def test_remove_lfs_flag(self):
+        Path(".gitattributes").write_text(
+            "*.bin filter=lfs diff=lfs -text\n"
+            "*.txt text\n"
+        )
+        Path("data.bin").write_bytes(b"real binary content")
+
+        runner = CliRunner()
+        with patch("boto3.client") as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.return_value = mock_client
+            mock_client.upload_fileobj = Mock()
+            mock_client.head_object = Mock(
+                side_effect=ClientError(
+                    {"Error": {"Code": "404", "Message": "Not Found"}},
+                    "HeadObject",
+                )
+            )
+
+            result = runner.invoke(
+                cli,
+                ["migrate-from-lfs", "bucket", "prefix", "--remove-lfs"],
+            )
+
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            content = Path(".gitattributes").read_text()
+            self.assertNotIn("filter=lfs", content)
+            self.assertIn("*.txt text", content)
+
+    def test_fails_outside_git_repo(self):
+        shutil.rmtree(".git")
+        runner = CliRunner()
+        result = runner.invoke(cli, ["migrate-from-lfs", "bucket", "prefix"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("Not in a git repository", result.output)
+
+    def test_shows_file_sizes(self):
+        Path(".gitattributes").write_text("*.bin filter=lfs diff=lfs -text\n")
+        Path("data.bin").write_bytes(b"x" * 2048)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["migrate-from-lfs", "bucket", "prefix", "--dry-run"]
+        )
+        self.assertIn("KB", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_migrate_from_lfs.py
+++ b/test_migrate_from_lfs.py
@@ -145,8 +145,7 @@ class TestRemoveLfsFromGitattributes(unittest.TestCase):
 
     def test_removes_lfs_lines(self):
         self.ga_path.write_text(
-            "*.bin filter=lfs diff=lfs merge=lfs -text\n"
-            "*.txt text\n"
+            "*.bin filter=lfs diff=lfs merge=lfs -text\n" "*.txt text\n"
         )
         _remove_lfs_from_gitattributes(self.ga_path, ["*.bin"])
         content = self.ga_path.read_text()
@@ -155,8 +154,7 @@ class TestRemoveLfsFromGitattributes(unittest.TestCase):
 
     def test_preserves_comments(self):
         self.ga_path.write_text(
-            "# Important comment\n"
-            "*.bin filter=lfs diff=lfs -text\n"
+            "# Important comment\n" "*.bin filter=lfs diff=lfs -text\n"
         )
         _remove_lfs_from_gitattributes(self.ga_path, ["*.bin"])
         content = self.ga_path.read_text()
@@ -257,9 +255,7 @@ class TestMigrateFromLfsCommand(unittest.TestCase):
                 )
             )
 
-            result = runner.invoke(
-                cli, ["migrate-from-lfs", "my-bucket", "my-prefix"]
-            )
+            result = runner.invoke(cli, ["migrate-from-lfs", "my-bucket", "my-prefix"])
 
             self.assertEqual(result.exit_code, 0, msg=result.output)
             self.assertIn("Migration complete", result.output)
@@ -272,8 +268,7 @@ class TestMigrateFromLfsCommand(unittest.TestCase):
 
     def test_remove_lfs_flag(self):
         Path(".gitattributes").write_text(
-            "*.bin filter=lfs diff=lfs -text\n"
-            "*.txt text\n"
+            "*.bin filter=lfs diff=lfs -text\n" "*.txt text\n"
         )
         Path("data.bin").write_bytes(b"real binary content")
 


### PR DESCRIPTION
## Summary

- Adds `s3lfs migrate-from-lfs <bucket> <prefix>` command for one-step Git LFS migration
- Parses `.gitattributes` for `filter=lfs` patterns to discover LFS-tracked files
- Validates all files contain real content — errors with clear instructions if pointer files are detected
- Initializes s3lfs, uploads all matched files to S3, creates the manifest
- `--dry-run` previews the migration (lists files and sizes) without making changes
- `--remove-lfs` cleans up LFS entries from `.gitattributes` after migration
- Shows human-readable file sizes and total during preview
- Helper functions: `_is_lfs_pointer`, `_parse_lfs_patterns`, `_find_lfs_files`, `_remove_lfs_from_gitattributes`

## Test plan

- [x] 27 new tests in `test_migrate_from_lfs.py` covering:
  - Pointer file detection (real content, pointer, empty, missing)
  - `.gitattributes` parsing (standard entries, comments, no LFS, directory patterns)
  - File discovery (glob matching, recursive, dedup, `.git` exclusion)
  - `.gitattributes` cleanup (remove LFS lines, preserve comments/other entries)
  - CLI: missing `.gitattributes`, no LFS patterns, already initialized, pointer files, no matches, dry run, successful migration, `--remove-lfs`, outside git repo, file size display
- [x] All 115 existing CLI tests still pass

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)