### PR TITLE
Add GitHub Action for CI/CD integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,57 @@ Periodically clean up unreferenced files (use with caution - this feature is unt
 s3lfs cleanup
 ```
 
+## CI/CD Integration
+
+### GitHub Action
+
+Use the built-in GitHub Action to install s3lfs and checkout tracked files in your workflows:
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+
+  - uses: aws-actions/configure-aws-credentials@v4
+    with:
+      aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      aws-region: us-east-1
+
+  - uses: kmatzen/s3lfs@main
+    with:
+      checkout: all
+```
+
+#### Selective Checkout
+
+Only download the files your pipeline needs — no wasted bandwidth:
+
+```yaml
+  - uses: kmatzen/s3lfs@main
+    with:
+      checkout: "assets/textures/**"
+```
+
+#### Action Inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `version` | `latest` | s3lfs version to install |
+| `checkout` | `none` | `all`, a glob pattern, or `none` (install only) |
+| `no-sign-request` | `false` | Use unsigned S3 requests (public buckets) |
+| `use-acceleration` | `false` | Enable S3 Transfer Acceleration |
+
+See [`examples/`](examples/) for complete workflow files.
+
+### Other CI Systems
+
+For GitLab CI, Jenkins, or other systems, install s3lfs directly:
+
+```sh
+pip install s3lfs
+s3lfs checkout --all           # or a selective glob
+```
+
 ## Configuration
 
 ### AWS Credentials

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,54 @@
+name: "s3lfs"
+description: "Install s3lfs and optionally checkout tracked files from S3"
+branding:
+  icon: "upload-cloud"
+  color: "orange"
+
+inputs:
+  version:
+    description: "s3lfs version to install (default: latest)"
+    required: false
+    default: "latest"
+  checkout:
+    description: "Files to checkout after install. Use 'all' for everything, a glob pattern for selective checkout, or 'none' to skip."
+    required: false
+    default: "none"
+  no-sign-request:
+    description: "Use unsigned S3 requests (for public buckets)"
+    required: false
+    default: "false"
+  use-acceleration:
+    description: "Enable S3 Transfer Acceleration"
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install s3lfs
+      shell: bash
+      run: |
+        if [ "${{ inputs.version }}" = "latest" ]; then
+          pip install s3lfs
+        else
+          pip install "s3lfs==${{ inputs.version }}"
+        fi
+        echo "s3lfs $(s3lfs --version 2>/dev/null || echo 'installed')"
+
+    - name: Checkout s3lfs files
+      if: inputs.checkout != 'none'
+      shell: bash
+      run: |
+        FLAGS=""
+        if [ "${{ inputs.no-sign-request }}" = "true" ]; then
+          FLAGS="$FLAGS --no-sign-request"
+        fi
+        if [ "${{ inputs.use-acceleration }}" = "true" ]; then
+          FLAGS="$FLAGS --use-acceleration"
+        fi
+
+        if [ "${{ inputs.checkout }}" = "all" ]; then
+          s3lfs checkout --all $FLAGS
+        else
+          s3lfs checkout "${{ inputs.checkout }}" $FLAGS
+        fi

--- a/examples/ci-checkout-all.yml
+++ b/examples/ci-checkout-all.yml
@@ -1,0 +1,28 @@
+# Example: Checkout all s3lfs-tracked files in CI
+#
+# Copy this file to .github/workflows/ and adjust to your needs.
+# Requires AWS credentials configured via aws-actions/configure-aws-credentials
+# or environment variables.
+
+name: Build with s3lfs assets
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - uses: kmatzen/s3lfs@main
+        with:
+          checkout: all

--- a/examples/ci-public-bucket.yml
+++ b/examples/ci-public-bucket.yml
@@ -1,0 +1,21 @@
+# Example: Checkout from a public S3 bucket (no AWS credentials needed)
+#
+# Use --no-sign-request for public buckets. No aws-actions/configure-aws-credentials needed.
+
+name: Build with public assets
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: kmatzen/s3lfs@main
+        with:
+          checkout: all
+          no-sign-request: "true"

--- a/examples/ci-selective-checkout.yml
+++ b/examples/ci-selective-checkout.yml
@@ -1,0 +1,28 @@
+# Example: Checkout only specific s3lfs files needed for a build
+#
+# This avoids downloading all tracked files, saving time and bandwidth.
+# Useful when your repo tracks many large files but a given job only needs a subset.
+
+name: Build with selective assets
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      # Only download texture assets needed for the build
+      - uses: kmatzen/s3lfs@main
+        with:
+          checkout: "assets/textures/**"


### PR DESCRIPTION
## Summary

- Adds `action.yml` as a composite GitHub Action, making the repo usable as `kmatzen/s3lfs@main` in workflows
- Installs s3lfs via pip (configurable version) and optionally checks out tracked files
- Supports selective checkout via glob patterns (`checkout: "assets/**"`) — only download what the pipeline needs
- Supports public buckets (`no-sign-request: true`) and transfer acceleration
- Includes 3 example workflows in `examples/`:
  - `ci-checkout-all.yml` — full checkout with AWS credentials
  - `ci-selective-checkout.yml` — download only specific assets
  - `ci-public-bucket.yml` — no credentials needed
- Documents the action inputs and CI/CD patterns in README

## Usage

```yaml
- uses: kmatzen/s3lfs@main
  with:
    checkout: all  # or "assets/**" or "none"
```

## Test plan

- [x] `action.yml` validated as valid YAML
- [x] All existing tests still pass (88 CLI tests)
- [ ] Manual: test in a real workflow after merge (composite actions can't be tested locally)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)