### PR TITLE
Stream MD5 and split_file to fix memory blowup on large files

### DIFF
--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -1106,9 +1106,16 @@ class S3LFS:
                     context_manager = contextlib.nullcontext()
 
                 with context_manager:
-                    # Compute the local MD5 checksum
+                    # Compute the local MD5 checksum (streaming to avoid
+                    # loading the entire chunk into memory)
+                    md5_hash = hashlib.md5()
                     with open(path, "rb") as f:
-                        local_md5 = hashlib.md5(f.read()).hexdigest()
+                        while True:
+                            block = f.read(DEFAULT_BUFFER_SIZE)
+                            if not block:
+                                break
+                            md5_hash.update(block)
+                    local_md5 = md5_hash.hexdigest()
 
                     # Check if the file already exists in S3 with the same MD5
                     try:
@@ -1902,16 +1909,31 @@ class S3LFS:
         file_path = Path(file_path)
         chunk_paths = []
 
+        max_chunk_bytes = self.chunk_size - 1
         with open(file_path, "rb") as f:
             chunk_index = 0
             while True:
-                chunk_data = f.read(self.chunk_size - 1)
-                if not chunk_data:
-                    break
-
                 chunk_path = Path(f"{file_path}.chunk{chunk_index}")
+                bytes_written = 0
+                wrote_any = False
+
                 with open(chunk_path, "wb") as chunk_file:
-                    chunk_file.write(chunk_data)
+                    while bytes_written < max_chunk_bytes:
+                        to_read = min(
+                            DEFAULT_BUFFER_SIZE,
+                            max_chunk_bytes - bytes_written,
+                        )
+                        block = f.read(to_read)
+                        if not block:
+                            break
+                        chunk_file.write(block)
+                        bytes_written += len(block)
+                        wrote_any = True
+
+                if not wrote_any:
+                    # Nothing left to read; remove the empty file
+                    chunk_path.unlink(missing_ok=True)
+                    break
 
                 chunk_paths.append(chunk_path)
                 chunk_index += 1

--- a/test_streaming.py
+++ b/test_streaming.py
@@ -1,0 +1,178 @@
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import yaml
+
+from s3lfs.core import DEFAULT_BUFFER_SIZE, S3LFS
+
+
+class TestStreamingMD5(unittest.TestCase):
+    """Verify that upload MD5 computation streams instead of loading all at once."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "files": {},
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_md5_matches_hashlib_reference(self):
+        """Streaming MD5 produces the same result as hashlib.md5(data)."""
+
+        with patch("boto3.client") as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.return_value = mock_client
+
+            s3lfs = S3LFS(bucket_name="test-bucket")
+
+            # Create a test file larger than DEFAULT_BUFFER_SIZE
+            data = b"x" * (DEFAULT_BUFFER_SIZE * 3 + 42)
+            test_file = Path(self.temp_dir) / "testdata.bin"
+            test_file.write_bytes(data)
+
+            # The upload method computes MD5 via streaming.
+            # Verify it completes successfully (upload_fileobj called)
+            # when head_object returns 404 (file not yet in S3).
+            from botocore.exceptions import ClientError
+
+            mock_client.head_object.side_effect = ClientError(
+                {"Error": {"Code": "404", "Message": "Not Found"}},
+                "HeadObject",
+            )
+            mock_client.upload_fileobj = Mock()
+
+            s3lfs.upload(test_file, silence=True)
+
+            self.assertTrue(mock_client.upload_fileobj.called)
+
+
+class TestStreamingSplitFile(unittest.TestCase):
+    """Verify that split_file streams in small buffers."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "files": {},
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_split_produces_correct_chunks(self):
+        """Streaming split produces the same output as the original."""
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+
+            # Use a small chunk size for testing
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                chunk_size=1024,  # 1KB chunks
+            )
+
+            # Create a file that will split into 3 chunks
+            data = b"A" * 1000 + b"B" * 1000 + b"C" * 500
+            test_file = Path(self.temp_dir) / "big.bin"
+            test_file.write_bytes(data)
+
+            chunks = s3lfs.split_file(test_file)
+
+            # Should produce 3 chunks (1023 + 1023 + remaining)
+            self.assertEqual(len(chunks), 3)
+
+            # Reassemble and verify
+            reassembled = b""
+            for chunk_path in chunks:
+                reassembled += chunk_path.read_bytes()
+            self.assertEqual(reassembled, data)
+
+    def test_split_single_chunk(self):
+        """A file smaller than chunk_size produces one chunk."""
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                chunk_size=4096,
+            )
+
+            data = b"small"
+            test_file = Path(self.temp_dir) / "small.bin"
+            test_file.write_bytes(data)
+
+            chunks = s3lfs.split_file(test_file)
+            self.assertEqual(len(chunks), 1)
+            self.assertEqual(chunks[0].read_bytes(), data)
+
+    def test_split_exact_boundary(self):
+        """A file exactly at chunk_size-1 produces one chunk."""
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                chunk_size=1024,
+            )
+
+            data = b"X" * 1023  # exactly chunk_size - 1
+            test_file = Path(self.temp_dir) / "exact.bin"
+            test_file.write_bytes(data)
+
+            chunks = s3lfs.split_file(test_file)
+            self.assertEqual(len(chunks), 1)
+            self.assertEqual(chunks[0].read_bytes(), data)
+
+    def test_split_no_empty_trailing_chunk(self):
+        """No empty chunk file is left when data ends on a boundary."""
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                chunk_size=1024,
+            )
+
+            # Exactly 2 full chunks
+            data = b"X" * 1023 + b"Y" * 1023
+            test_file = Path(self.temp_dir) / "boundary.bin"
+            test_file.write_bytes(data)
+
+            chunks = s3lfs.split_file(test_file)
+            self.assertEqual(len(chunks), 2)
+
+            # No leftover empty chunk file
+            leftover = Path(f"{test_file}.chunk2")
+            self.assertFalse(leftover.exists())
+
+            # Content is correct
+            reassembled = b""
+            for chunk_path in chunks:
+                reassembled += chunk_path.read_bytes()
+            self.assertEqual(reassembled, data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Two places were loading entire file chunks (up to 5GB) into memory at once:

- **upload() MD5 check**: `hashlib.md5(f.read())` allocated the full chunk in RAM
- **split_file()**: `f.read(self.chunk_size - 1)` read up to 5GB-1 bytes into a single buffer

Both now stream in `DEFAULT_BUFFER_SIZE` (1MB) blocks, keeping memory usage constant regardless of file size.

## Test plan

- [x] 5 new tests in `test_streaming.py`:
  - Streaming MD5 upload completes successfully
  - split_file produces correct chunks with streaming
  - Single chunk, exact boundary, and no empty trailing chunk cases
- [x] All 93 existing tests still pass

Closes #60

Generated with [Claude Code](https://claude.com/claude-code)