### PR TITLE
Add exponential backoff to retry decorator

### DIFF
--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -55,30 +55,29 @@ ERROR_MESSAGES = {
 }
 
 
-def retry(times, exceptions):
-    """
-    Retry Decorator
-    Retries the wrapped function/method `times` times if the exceptions listed
-    in ``exceptions`` are thrown
-    :param times: The number of times to repeat the wrapped function/method
-    :type times: Int
-    :param Exceptions: Lists of exceptions that trigger a retry attempt
-    :type Exceptions: Tuple of Exceptions
+def retry(times, exceptions, max_delay=30):
+    """Retry decorator with exponential backoff.
+
+    :param times: Maximum number of retry attempts.
+    :param exceptions: Tuple of exception types that trigger a retry.
+    :param max_delay: Cap on the backoff delay in seconds.
     """
 
     def decorator(func):
         def newfn(*args, **kwargs):
-            attempt = 0
-            while attempt < times:
+            for attempt in range(times):
                 try:
                     return func(*args, **kwargs)
                 except exceptions as exc:
-                    print(
-                        f"Exception thrown when attempting to run {func}, attempt "
-                        f"{attempt} of {times}: {exc}"
-                    )
-                    attempt += 1
-            return func(*args, **kwargs)
+                    if attempt < times - 1:
+                        delay = min(2 ** (attempt + 1), max_delay)
+                        print(
+                            f"Retry {attempt + 1}/{times} for {func.__name__} "
+                            f"in {delay}s: {exc}"
+                        )
+                        time.sleep(delay)
+                    else:
+                        raise
 
         return newfn
 

--- a/test_retry.py
+++ b/test_retry.py
@@ -1,0 +1,110 @@
+import unittest
+from unittest.mock import patch
+
+from s3lfs.core import retry
+
+
+class TestRetryDecorator(unittest.TestCase):
+    def test_no_retry_on_success(self):
+        call_count = [0]
+
+        @retry(3, (ValueError,))
+        def succeed():
+            call_count[0] += 1
+            return "ok"
+
+        result = succeed()
+        self.assertEqual(result, "ok")
+        self.assertEqual(call_count[0], 1)
+
+    def test_retries_on_exception(self):
+        call_count = [0]
+
+        @retry(3, (ValueError,))
+        def fail_then_succeed():
+            call_count[0] += 1
+            if call_count[0] < 3:
+                raise ValueError("transient")
+            return "ok"
+
+        with patch("time.sleep"):
+            result = fail_then_succeed()
+        self.assertEqual(result, "ok")
+        self.assertEqual(call_count[0], 3)
+
+    def test_raises_after_all_retries_exhausted(self):
+        call_count = [0]
+
+        @retry(3, (ValueError,))
+        def always_fail():
+            call_count[0] += 1
+            raise ValueError("permanent")
+
+        with patch("time.sleep"):
+            with self.assertRaises(ValueError):
+                always_fail()
+        self.assertEqual(call_count[0], 3)
+
+    def test_does_not_catch_unrelated_exceptions(self):
+        @retry(3, (ValueError,))
+        def raise_type_error():
+            raise TypeError("wrong type")
+
+        with self.assertRaises(TypeError):
+            raise_type_error()
+
+    def test_exponential_backoff_delays(self):
+        call_count = [0]
+        sleep_calls = []
+
+        @retry(4, (ValueError,))
+        def always_fail():
+            call_count[0] += 1
+            raise ValueError("fail")
+
+        with patch("time.sleep", side_effect=lambda d: sleep_calls.append(d)):
+            with self.assertRaises(ValueError):
+                always_fail()
+
+        # 3 sleeps for 4 attempts (no sleep after final failure)
+        self.assertEqual(len(sleep_calls), 3)
+        self.assertEqual(sleep_calls[0], 2)  # 2^1
+        self.assertEqual(sleep_calls[1], 4)  # 2^2
+        self.assertEqual(sleep_calls[2], 8)  # 2^3
+
+    def test_max_delay_cap(self):
+        sleep_calls = []
+
+        @retry(5, (ValueError,), max_delay=5)
+        def always_fail():
+            raise ValueError("fail")
+
+        with patch("time.sleep", side_effect=lambda d: sleep_calls.append(d)):
+            with self.assertRaises(ValueError):
+                always_fail()
+
+        # All delays should be capped at 5
+        for delay in sleep_calls:
+            self.assertLessEqual(delay, 5)
+
+    def test_no_sleep_on_first_attempt(self):
+        """First attempt should not sleep, even on failure."""
+        sleep_calls = []
+
+        @retry(2, (ValueError,))
+        def fail_once():
+            if not hasattr(fail_once, "_called"):
+                fail_once._called = True
+                raise ValueError("first fail")
+            return "ok"
+
+        with patch("time.sleep", side_effect=lambda d: sleep_calls.append(d)):
+            result = fail_once()
+
+        self.assertEqual(result, "ok")
+        # One sleep between attempt 1 and attempt 2
+        self.assertEqual(len(sleep_calls), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Retry decorator now sleeps with exponential backoff (2s, 4s, 8s, ...) between attempts, capped at `max_delay` (default 30s)
- Fixes a bug where the final attempt ran outside the retry loop, causing `times + 1` total calls and swallowing the last exception. Now raises on the last failed attempt.
- Unrelated exceptions still propagate immediately without retry

## Test plan

- [x] 7 new tests in `test_retry.py`:
  - No retry on success
  - Retries on matching exception, succeeds on later attempt
  - Raises after all retries exhausted
  - Unrelated exceptions propagate immediately
  - Backoff delays are 2, 4, 8 (exponential)
  - max_delay cap is respected
  - No sleep before the first attempt
- [x] All 82 existing tests still pass

Closes #66

Generated with [Claude Code](https://claude.com/claude-code)