### PR TITLE
Deduplicate metrics-conditional code with metrics.track()

### DIFF
--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -732,15 +732,7 @@ class S3LFS:
         """
         Compute the SHA-256 hash using memory-mapped files.
         """
-        if metrics.is_enabled():
-            tracker = metrics.get_tracker()
-            with tracker.track_task("hashing", str(file_path)):
-                hasher = hashlib.sha256()
-                with open(file_path, "rb") as f:
-                    with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
-                        hasher.update(mm)
-                return hasher.hexdigest()
-        else:
+        with metrics.track("hashing", str(file_path)):
             hasher = hashlib.sha256()
             with open(file_path, "rb") as f:
                 with mmap.mmap(f.fileno(), 0, access=mmap.ACCESS_READ) as mm:
@@ -751,15 +743,7 @@ class S3LFS:
         """
         Compute the SHA-256 hash by iteratively reading the file in chunks.
         """
-        if metrics.is_enabled():
-            tracker = metrics.get_tracker()
-            with tracker.track_task("hashing", str(file_path)):
-                hasher = hashlib.sha256()
-                with open(file_path, "rb") as f:
-                    while chunk := f.read(chunk_size):
-                        hasher.update(chunk)
-                return hasher.hexdigest()
-        else:
+        with metrics.track("hashing", str(file_path)):
             hasher = hashlib.sha256()
             with open(file_path, "rb") as f:
                 while chunk := f.read(chunk_size):
@@ -900,26 +884,7 @@ class S3LFS:
         """
         Compress the file deterministically using Python's gzip module.
         """
-        if metrics.is_enabled():
-            tracker = metrics.get_tracker()
-            with tracker.track_task("compression", str(file_path)):
-                compressed_path = self.temp_dir / f"{uuid4()}.gz"
-                buffer_size = DEFAULT_BUFFER_SIZE
-
-                with open(file_path, "rb") as f_in, open(
-                    compressed_path, "wb"
-                ) as f_out:
-                    with gzip.GzipFile(
-                        filename="",  # avoid embedding filename
-                        mode="wb",
-                        fileobj=f_out,
-                        compresslevel=5,
-                        mtime=0,  # fixed mtime for determinism
-                    ) as gz_out:
-                        shutil.copyfileobj(f_in, gz_out, length=buffer_size)
-
-                return compressed_path
-        else:
+        with metrics.track("compression", str(file_path)):
             compressed_path = self.temp_dir / f"{uuid4()}.gz"
             buffer_size = DEFAULT_BUFFER_SIZE
 
@@ -993,31 +958,13 @@ class S3LFS:
         """
         Decompress the file using Python's gzip module and save it to the output path.
         """
-        if metrics.is_enabled():
-            tracker = metrics.get_tracker()
-            with tracker.track_task("decompression", str(output_path)):
-                with gzip.open(compressed_path, "rb") as f_in:
-                    with open(output_path, "wb") as f_out:
-                        # Use manual chunked copy to avoid type issues
-                        while True:
-                            chunk = f_in.read(DEFAULT_BUFFER_SIZE)  # 1MB chunks
-                            if not chunk:
-                                break
-                            # Ensure we have bytes for writing
-                            if isinstance(chunk, str):
-                                chunk = chunk.encode("utf-8")
-                            f_out.write(chunk)
-
-                return output_path
-        else:
+        with metrics.track("decompression", str(output_path)):
             with gzip.open(compressed_path, "rb") as f_in:
                 with open(output_path, "wb") as f_out:
-                    # Use manual chunked copy to avoid type issues
                     while True:
-                        chunk = f_in.read(DEFAULT_BUFFER_SIZE)  # 1MB chunks
+                        chunk = f_in.read(DEFAULT_BUFFER_SIZE)
                         if not chunk:
                             break
-                        # Ensure we have bytes for writing
                         if isinstance(chunk, str):
                             chunk = chunk.encode("utf-8")
                         f_out.write(chunk)
@@ -1138,26 +1085,13 @@ class S3LFS:
                             raise  # Re-raise if it's not a "Not Found" error
 
                     # Proceed with the upload if MD5 does not match or file does not exist
-                    if metrics.is_enabled():
-                        tracker = metrics.get_tracker()
-                        with tracker.track_task("s3_upload", str(path)):
-                            with open(path, "rb") as f:
-                                self._get_s3_client().upload_fileobj(
-                                    f,
-                                    self.bucket_name,
-                                    s3_key
-                                    if not chunked
-                                    else f"{s3_key}.chunk{chunk_idx}",
-                                    ExtraArgs=extra_args,
-                                    Config=self.config,
-                                    Callback=upload_callback,
-                                )
-                    else:
+                    upload_key = s3_key if not chunked else f"{s3_key}.chunk{chunk_idx}"
+                    with metrics.track("s3_upload", str(path)):
                         with open(path, "rb") as f:
                             self._get_s3_client().upload_fileobj(
                                 f,
                                 self.bucket_name,
-                                s3_key if not chunked else f"{s3_key}.chunk{chunk_idx}",
+                                upload_key,
                                 ExtraArgs=extra_args,
                                 Config=self.config,
                                 Callback=upload_callback,
@@ -1980,15 +1914,7 @@ class S3LFS:
 
             # Check if file exists and has correct hash
             if filesystem_path.exists():
-                # Track hashing even when cached (for metrics visibility)
-                if metrics.is_enabled():
-                    tracker = metrics.get_tracker()
-                    with tracker.track_task("hashing", str(filesystem_path)):
-                        if use_cache:
-                            current_hash = self.hash_file_cached(filesystem_path)
-                        else:
-                            current_hash = self.hash_file(filesystem_path)
-                else:
+                with metrics.track("hashing", str(filesystem_path)):
                     if use_cache:
                         current_hash = self.hash_file_cached(filesystem_path)
                     else:
@@ -2406,17 +2332,7 @@ class S3LFS:
                 with context_manager:
                     if not silence:
                         print(f"Downloading {key} to {target_path}")
-                    if metrics.is_enabled():
-                        tracker = metrics.get_tracker()
-                        with tracker.track_task("s3_download", key):
-                            with open(target_path, "wb") as f:
-                                self._get_s3_client().download_fileobj(
-                                    Bucket=self.bucket_name,
-                                    Key=key,
-                                    Fileobj=f,
-                                    Callback=download_callback,
-                                )
-                    else:
+                    with metrics.track("s3_download", key):
                         with open(target_path, "wb") as f:
                             self._get_s3_client().download_fileobj(
                                 Bucket=self.bucket_name,
@@ -2437,12 +2353,7 @@ class S3LFS:
         if os.path.dirname(filesystem_path):
             os.makedirs(os.path.dirname(filesystem_path), exist_ok=True)
         try:
-            # Track decompression at the call site for better metrics visibility
-            if metrics.is_enabled():
-                tracker = metrics.get_tracker()
-                with tracker.track_task("decompression", str(filesystem_path)):
-                    self.decompress_file(compressed_path, filesystem_path)
-            else:
+            with metrics.track("decompression", str(filesystem_path)):
                 self.decompress_file(compressed_path, filesystem_path)
         except Exception as e:
             print(f"❌ Error decompressing {compressed_path} for key {keys}: {e}")

--- a/s3lfs/metrics.py
+++ b/s3lfs/metrics.py
@@ -264,3 +264,17 @@ def disable_metrics() -> None:
 def is_enabled() -> bool:
     """Check if metrics collection is enabled."""
     return _global_tracker is not None
+
+
+@contextmanager
+def track(stage_name, task_id):
+    """Context manager that tracks a task when metrics are enabled.
+
+    When metrics are disabled this is a no-op, so callers never need
+    an if/else branch.
+    """
+    if _global_tracker is not None:
+        with _global_tracker.track_task(stage_name, task_id):
+            yield
+    else:
+        yield

--- a/test_metrics_track.py
+++ b/test_metrics_track.py
@@ -1,0 +1,51 @@
+import unittest
+
+from s3lfs import metrics
+
+
+class TestMetricsTrack(unittest.TestCase):
+    """Tests for the metrics.track() context manager."""
+
+    def setUp(self):
+        # Reset global state
+        metrics._global_tracker = None
+
+    def tearDown(self):
+        metrics._global_tracker = None
+
+    def test_noop_when_disabled(self):
+        """When metrics are disabled, track() is a no-op."""
+        self.assertFalse(metrics.is_enabled())
+        result = None
+        with metrics.track("hashing", "test.txt"):
+            result = 42
+        self.assertEqual(result, 42)
+
+    def test_tracks_when_enabled(self):
+        """When metrics are enabled, track() records the task."""
+        tracker = metrics.enable_metrics()
+        tracker.start_pipeline()
+        tracker.start_stage("hashing", max_workers=4)
+
+        with metrics.track("hashing", "test.txt"):
+            pass
+
+        stage = tracker._metrics.get_or_create_stage("hashing")
+        self.assertEqual(stage.completed_tasks, 1)
+
+    def test_propagates_exceptions(self):
+        """Exceptions inside track() propagate normally."""
+        with self.assertRaises(ValueError):
+            with metrics.track("hashing", "test.txt"):
+                raise ValueError("test error")
+
+    def test_return_value_accessible(self):
+        """Code inside track() can produce results normally."""
+        results = []
+        with metrics.track("compression", "file.bin"):
+            results.append("compressed")
+        self.assertEqual(results, ["compressed"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `metrics.track(stage_name, task_id)` - a context manager that wraps with `tracker.track_task` when metrics are enabled, and is a no-op otherwise. This eliminates the repeated pattern of:

```python
if metrics.is_enabled():
    with tracker.track_task("stage", label):
        <body>
else:
    <same body>
```

which appeared in 7 methods across core.py. Each is now just:

```python
with metrics.track("stage", label):
    <body>
```

Net change: -100 lines, +76 lines (24 lines removed).

### Methods cleaned up

- `_hash_file_mmap`
- `_hash_file_iter`
- `_compress_file_python`
- `_decompress_file_python`
- `upload` (s3_upload tracking)
- `download` (s3_download and decompression tracking)
- `_hash_and_download_worker`

Pipeline lifecycle calls (`start_pipeline`, `start_stage`, etc.) are left as-is since they manage stage state rather than wrapping duplicated code.

## Test plan

- [x] 4 new tests in `test_metrics_track.py`:
  - No-op when disabled
  - Records task when enabled
  - Propagates exceptions
  - Code inside produces results normally
- [x] All 96 existing tests still pass

Closes #67

Generated with [Claude Code](https://claude.com/claude-code)