### PR TITLE
Reduce manifest/cache lock contention for bulk operations

### DIFF
--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -707,58 +707,92 @@ class S3LFS:
                 print(f"Cleaned up {len(stale_entries)} stale cache entries.")
                 self.save_cache()
 
+    def _check_cache_hit(self, file_path_str, current_metadata):
+        """Check if the in-memory cache has a valid entry for this file.
+
+        Does NOT acquire the lock or reload cache from disk.
+        Returns the cached hash if valid, or None.
+        """
+        cached_data = self.hash_cache.get(file_path_str)
+        if not cached_data:
+            return None
+        cached_meta = cached_data.get("metadata", {})
+        if (
+            cached_meta.get("size") == current_metadata["size"]
+            and cached_meta.get("mtime") == current_metadata["mtime"]
+            and cached_meta.get("inode") == current_metadata["inode"]
+        ):
+            return cached_data["hash"]
+        return None
+
     def track_modified_files_cached(self, silence=True):
         """
-        Check manifest for outdated hashes using cached hashing and upload changed files in parallel.
-        This is an optimized version of track_modified_files that uses hash caching.
+        Check manifest for outdated hashes using cached hashing and upload
+        changed files in parallel.
+
+        Loads the manifest and cache once at the start, checks all files
+        against the in-memory snapshot without holding the lock, and
+        batch-writes cache updates at the end.
         """
         files_to_upload = []
         cache_hits = 0
         cache_misses = 0
 
+        # Load manifest and cache once, snapshot stored hashes
         with self._lock_context():
-            files_to_check = list(
-                self.manifest["files"].keys()
-            )  # Files listed in the manifest
+            files_to_check = list(self.manifest["files"].keys())
+            stored_hashes = dict(self.manifest["files"])
+            self.load_cache()
 
         if not files_to_check:
             print(
-                "⚠️ No files found in manifest. Use 's3lfs track <path>' to track files first."
+                "No files found in manifest. "
+                "Use 's3lfs track <path>' to track files first."
             )
             return
 
-        print(f"🔍 Checking {len(files_to_check)} tracked files for modifications...")
+        print(f"Checking {len(files_to_check)} tracked files for modifications...")
 
-        # Use cached hashing for better performance with progress indication
+        cache_updates = {}
+
         with tqdm(
             total=len(files_to_check), desc="Checking files", unit="file"
         ) as pbar:
             for file_path in files_to_check:
                 try:
-                    # Get file status to check cache validity
-                    status = self.get_file_status(file_path)
+                    fp = Path(file_path)
+                    filesystem_path = self.path_resolver.to_filesystem_path(file_path)
 
-                    if not status["exists"]:
-                        print(f"⚠️ Warning: File {file_path} is missing. Skipping.")
+                    if not filesystem_path.exists():
+                        print(f"Warning: File {file_path} is missing. Skipping.")
                         pbar.update(1)
                         continue
 
-                    # Use cached hash if available and valid
-                    if status["cache_valid"]:
-                        current_hash = status["cached_hash"]
+                    stat = filesystem_path.stat()
+                    metadata = {
+                        "size": stat.st_size,
+                        "mtime": stat.st_mtime,
+                        "inode": getattr(stat, "st_ino", None),
+                    }
+                    file_path_str = str(fp.as_posix())
+
+                    cached_hash = self._check_cache_hit(file_path_str, metadata)
+                    if cached_hash is not None:
+                        current_hash = cached_hash
                         cache_hits += 1
                     else:
-                        current_hash = self.hash_file_cached(file_path)
+                        current_hash = self.hash_file(filesystem_path)
                         cache_misses += 1
+                        cache_updates[file_path_str] = {
+                            "hash": current_hash,
+                            "metadata": metadata,
+                            "timestamp": time.time(),
+                        }
 
-                    with self._lock_context():
-                        stored_hash = self.manifest["files"].get(file_path)
-
-                    if current_hash != stored_hash:
-                        print(f"📝 File {file_path} has changed. Marking for upload.")
+                    if current_hash != stored_hashes.get(file_path):
+                        print(f"File {file_path} has changed. " f"Marking for upload.")
                         files_to_upload.append(file_path)
 
-                    # Update progress bar with current status
                     pbar.set_postfix(
                         {
                             "changed": len(files_to_upload),
@@ -769,23 +803,33 @@ class S3LFS:
                     pbar.update(1)
 
                 except Exception as e:
-                    print(f"❌ Error processing {file_path}: {e}")
+                    print(f"Error processing {file_path}: {e}")
                     pbar.update(1)
                     continue
 
+        # Batch-write cache updates in a single lock acquisition
+        if cache_updates:
+            with self._lock_context():
+                self.hash_cache.update(cache_updates)
+                self._cache_dirty = True
+                self.save_cache()
+
         if not silence:
-            print(f"📊 Hash cache performance: {cache_hits} hits, {cache_misses} misses")
+            print(
+                f"Hash cache performance: " f"{cache_hits} hits, {cache_misses} misses"
+            )
 
         # Upload files in parallel if needed
         if files_to_upload:
-            print(f"📤 Uploading {len(files_to_upload)} modified file(s) in parallel...")
+            print(
+                f"Uploading {len(files_to_upload)} modified file(s) " f"in parallel..."
+            )
             self.parallel_upload(files_to_upload, silence=silence)
 
-            # Save updated manifest (including cache)
             with self._lock_context():
                 self.save_manifest()
         else:
-            print("✅ No modified files needing upload.")
+            print("No modified files needing upload.")
 
     def _hash_file_mmap(self, file_path):
         """

--- a/test_lock_contention.py
+++ b/test_lock_contention.py
@@ -2,8 +2,8 @@ import os
 import shutil
 import tempfile
 import unittest
-from pathlib import Path
 from contextlib import contextmanager
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import yaml

--- a/test_lock_contention.py
+++ b/test_lock_contention.py
@@ -1,0 +1,219 @@
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
+
+import yaml
+
+from s3lfs.core import S3LFS
+
+
+class TestCheckCacheHit(unittest.TestCase):
+    """Tests for _check_cache_hit helper."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "files": {},
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_returns_hash_on_match(self):
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+            s3lfs = S3LFS(bucket_name="test-bucket")
+            s3lfs.hash_cache = {
+                "file.txt": {
+                    "hash": "abc123",
+                    "metadata": {"size": 100, "mtime": 1.0, "inode": 42},
+                }
+            }
+            result = s3lfs._check_cache_hit(
+                "file.txt", {"size": 100, "mtime": 1.0, "inode": 42}
+            )
+            self.assertEqual(result, "abc123")
+
+    def test_returns_none_on_size_mismatch(self):
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+            s3lfs = S3LFS(bucket_name="test-bucket")
+            s3lfs.hash_cache = {
+                "file.txt": {
+                    "hash": "abc123",
+                    "metadata": {"size": 100, "mtime": 1.0, "inode": 42},
+                }
+            }
+            result = s3lfs._check_cache_hit(
+                "file.txt", {"size": 200, "mtime": 1.0, "inode": 42}
+            )
+            self.assertIsNone(result)
+
+    def test_returns_none_on_missing_entry(self):
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+            s3lfs = S3LFS(bucket_name="test-bucket")
+            s3lfs.hash_cache = {}
+            result = s3lfs._check_cache_hit(
+                "file.txt", {"size": 100, "mtime": 1.0, "inode": 42}
+            )
+            self.assertIsNone(result)
+
+
+class TestTrackModifiedReducedLocking(unittest.TestCase):
+    """Verify track_modified_files_cached minimizes lock acquisitions."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_loads_cache_once_for_many_files(self):
+        """Cache is loaded once at start, not per file."""
+        # Create manifest with multiple files
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "files": {
+                "a.txt": "hash_a",
+                "b.txt": "hash_b",
+                "c.txt": "hash_c",
+            },
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+        # Create the files
+        for name in ["a.txt", "b.txt", "c.txt"]:
+            Path(name).write_text(f"content of {name}")
+
+        with patch("boto3.client") as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.return_value = mock_client
+            mock_client.head_object.return_value = {"ContentLength": 10}
+            mock_client.upload_fileobj = Mock()
+
+            s3lfs = S3LFS(bucket_name="test-bucket")
+
+            # Count how many times load_cache is called
+            load_count = [0]
+            original_load = s3lfs.load_cache
+
+            def counting_load(*args, **kwargs):
+                load_count[0] += 1
+                return original_load(*args, **kwargs)
+
+            with patch.object(s3lfs, "load_cache", side_effect=counting_load):
+                s3lfs.track_modified_files_cached(silence=True)
+
+            # Should load cache a small constant number of times,
+            # NOT once per file (which would be 3+)
+            # The initial __init__ also calls load_cache, so we
+            # only count from this point.
+            # Expect: 1 load in the method + possibly 1 for save
+            self.assertLessEqual(
+                load_count[0],
+                2,
+                f"load_cache called {load_count[0]} times for 3 files, "
+                f"expected at most 2",
+            )
+
+    def test_saves_cache_once_at_end(self):
+        """Cache is saved in a single batch at the end, not per file."""
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "files": {
+                "a.txt": "old_hash",
+                "b.txt": "old_hash",
+            },
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+        for name in ["a.txt", "b.txt"]:
+            Path(name).write_text(f"new content of {name}")
+
+        with patch("boto3.client") as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.return_value = mock_client
+            mock_client.head_object.side_effect = Exception("not found")
+            mock_client.upload_fileobj = Mock()
+
+            s3lfs = S3LFS(bucket_name="test-bucket")
+
+            save_count = [0]
+            original_save = s3lfs.save_cache
+
+            def counting_save():
+                save_count[0] += 1
+                return original_save()
+
+            with patch.object(s3lfs, "save_cache", side_effect=counting_save):
+                s3lfs.track_modified_files_cached(silence=True)
+
+            # At most 1 save_cache call (the batch update at end)
+            self.assertLessEqual(
+                save_count[0],
+                1,
+                f"save_cache called {save_count[0]} times, expected at most 1",
+            )
+
+    def test_does_not_lock_per_file_for_manifest_reads(self):
+        """Manifest stored_hash lookups use the snapshot, not per-file locks."""
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "test-prefix",
+            "files": {"x.txt": "hash_x"},
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+        Path("x.txt").write_text("content")
+
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+
+            s3lfs = S3LFS(bucket_name="test-bucket")
+
+            original_lock = s3lfs._lock_context
+            lock_count = [0]
+
+            @contextmanager
+            def counting_lock():
+                lock_count[0] += 1
+                with original_lock():
+                    yield
+
+            with patch.object(s3lfs, "_lock_context", side_effect=counting_lock):
+                s3lfs.track_modified_files_cached(silence=True)
+
+            # Should be a small constant (1 for initial load, maybe
+            # 1 for cache save), not 1-per-file
+            self.assertLessEqual(
+                lock_count[0],
+                3,
+                f"Lock acquired {lock_count[0]} times, expected at most 3",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

`track_modified_files_cached` was acquiring the file lock 2-3 times per tracked file: once to read the manifest, once inside `hash_file_cached` to load the cache, and once to save the cache. For 1000 files that meant 2000-3000 lock-open-parse-YAML-close cycles.

Now:
- Manifest and cache are loaded once into memory at the start (1 lock)
- All files are checked against the in-memory snapshot without holding the lock
- Cache updates are accumulated in a dict and written in a single batch at the end (1 lock)
- Total: 2 lock acquisitions for N files, down from 2-3N

### New helper

`_check_cache_hit(file_path_str, current_metadata)` checks the in-memory cache dict directly without any lock acquisition or disk I/O.

## Test plan

- [x] 6 new tests in `test_lock_contention.py`:
  - `_check_cache_hit`: returns hash on match, None on mismatch, None on missing
  - Bulk operation: cache loaded at most 2 times for 3 files (not 3+)
  - Bulk operation: cache saved at most 1 time (batch, not per-file)
  - Bulk operation: lock acquired at most 3 times total (not per-file)
- [x] All 81 existing tests still pass

Closes #62

Generated with [Claude Code](https://claude.com/claude-code)