### PR TITLE
Apply dynamic parallel pattern to upload chunks

### DIFF
--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -1348,30 +1348,159 @@ class S3LFS:
             print("No modified files needing upload.")
 
     def parallel_upload(self, files, silence=True):
-        """Parallel upload of multiple files using ThreadPoolExecutor."""
-        # Test S3 credentials once before starting parallel operations
-        if not silence:
-            print("🔐 Testing S3 credentials...")
-        self.test_s3_credentials(silence=silence)
+        """Upload multiple files with block-level parallelism."""
+        self.parallel_upload_chunked(files, silence=silence)
 
-        with ThreadPoolExecutor(max_workers=self.workers) as executor:
-            # Submit each download task; unpack key from matching_files.items()
-            futures = [
-                executor.submit(
-                    self.upload, f, silence=silence, needs_immediate_update=False
-                )
-                for f in files
+    def _prepare_file_for_upload(self, file_path):
+        """Hash, compress, and split a file into uploadable chunks."""
+        file_path = Path(file_path)
+        file_hash = self.hash_file(file_path)
+        manifest_key = self._get_manifest_key(file_path)
+
+        with self._lock_context():
+            stored_hash = self.manifest["files"].get(manifest_key)
+        if file_hash == stored_hash:
+            return None
+
+        s3_key = f"{self.repo_prefix}/assets/{file_hash}/{manifest_key}.gz"
+        extra_args = {"ServerSideEncryption": "AES256"} if self.encryption else {}
+
+        compressed_path = self.compress_file(file_path)
+
+        if compressed_path.stat().st_size > self.chunk_size:
+            chunk_paths = self.split_file(compressed_path)
+            try:
+                os.remove(compressed_path)
+            except OSError:
+                pass
+            chunks = [
+                {
+                    "path": p,
+                    "s3_key": f"{s3_key}.chunk{i}",
+                    "chunk_index": i,
+                    "extra_args": extra_args,
+                }
+                for i, p in enumerate(chunk_paths)
+            ]
+        else:
+            chunks = [
+                {
+                    "path": compressed_path,
+                    "s3_key": s3_key,
+                    "chunk_index": 0,
+                    "extra_args": extra_args,
+                }
             ]
 
-            for future in tqdm(
-                as_completed(futures), total=len(futures), desc="Uploading files"
-            ):
-                try:
-                    # This will raise the exception if the download failed
-                    future.result()
-                except Exception as e:
-                    # Handle any other exceptions that may occur
-                    print(f"An error occurred: {e}")
+        return (manifest_key, file_hash, chunks)
+
+    def _upload_chunk(self, chunk_info):
+        """Upload a single compressed chunk to S3."""
+        path = chunk_info["path"]
+        s3_key = chunk_info["s3_key"]
+        extra_args = chunk_info["extra_args"]
+
+        try:
+            with open(path, "rb") as f:
+                self._get_s3_client().upload_fileobj(
+                    f,
+                    self.bucket_name,
+                    s3_key,
+                    ExtraArgs=extra_args,
+                    Config=self.config,
+                )
+            bytes_uploaded = path.stat().st_size
+        finally:
+            try:
+                os.remove(path)
+            except OSError:
+                pass
+
+        return (s3_key, bytes_uploaded)
+
+    def parallel_upload_chunked(self, files, silence=True):
+        """Upload files with dynamic block-level parallelism."""
+        if not files:
+            print("Nothing to upload.")
+            return
+
+        self.test_s3_credentials(silence=silence)
+
+        lock = threading.Lock()
+        manifest_updates = {}
+        counters = {"total_bytes": 0, "total_chunks": 0, "chunks_done": 0}
+
+        try:
+            with tqdm(desc="Uploading", unit="chunk") as pbar:
+                with ThreadPoolExecutor(max_workers=self.workers) as executor:
+                    pending = set()
+
+                    def on_prep_done(future):
+                        try:
+                            result = future.result()
+                        except Exception as e:
+                            print(f"Error preparing file: {e}")
+                            return
+
+                        if result is None:
+                            return
+
+                        manifest_key, file_hash, chunks = result
+                        with lock:
+                            manifest_updates[manifest_key] = file_hash
+                            counters["total_chunks"] += len(chunks)
+                            pbar.total = counters["total_chunks"]
+                            pbar.refresh()
+
+                        for chunk in chunks:
+                            ul_future = executor.submit(self._upload_chunk, chunk)
+                            pending.add(ul_future)
+
+                    for f in files:
+                        prep_future = executor.submit(self._prepare_file_for_upload, f)
+                        prep_future.add_done_callback(on_prep_done)
+                        pending.add(prep_future)
+
+                    while pending:
+                        if self._shutdown_requested:
+                            print(
+                                "Shutdown requested. " "Cancelling remaining uploads..."
+                            )
+                            break
+
+                        done = {fut for fut in list(pending) if fut.done()}
+                        if not done:
+                            time.sleep(0.01)
+                            continue
+
+                        for future in done:
+                            pending.discard(future)
+                            try:
+                                result = future.result()
+                            except Exception:
+                                continue
+
+                            if isinstance(result, tuple) and len(result) == 2:
+                                _, bytes_uploaded = result
+                                with lock:
+                                    counters["total_bytes"] += bytes_uploaded
+                                    counters["chunks_done"] += 1
+                                    pbar.update(1)
+
+        except KeyboardInterrupt:
+            print("\nUpload interrupted by user.")
+        finally:
+            if manifest_updates:
+                with self._lock_context():
+                    self.load_manifest()
+                    self.manifest["files"].update(manifest_updates)
+                    self.save_manifest()
+
+            print(
+                f"Uploaded {len(manifest_updates)} file(s) "
+                f"({counters['chunks_done']} chunks, "
+                f"{counters['total_bytes'] / (1024 * 1024):.1f} MB compressed)."
+            )
 
     def parallel_download_all(self, silence=True):
         """Download all files listed in the manifest in parallel."""

--- a/test_parallel_upload.py
+++ b/test_parallel_upload.py
@@ -1,0 +1,188 @@
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import yaml
+
+from s3lfs.core import S3LFS
+
+
+class TestPrepareFileForUpload(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "pfx",
+            "files": {},
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_returns_chunks_for_new_file(self):
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+            s3lfs = S3LFS(bucket_name="test-bucket")
+
+            Path("data.bin").write_bytes(b"hello world")
+            result = s3lfs._prepare_file_for_upload("data.bin")
+
+            self.assertIsNotNone(result)
+            manifest_key, file_hash, chunks = result
+            self.assertEqual(manifest_key, "data.bin")
+            self.assertGreater(len(chunks), 0)
+            self.assertTrue(chunks[0]["path"].exists())
+
+    def test_returns_none_when_hash_matches(self):
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+
+            Path("data.bin").write_bytes(b"content")
+            s3lfs = S3LFS(bucket_name="test-bucket")
+
+            # Compute hash and store in manifest
+            h = s3lfs.hash_file("data.bin")
+            with s3lfs._lock_context():
+                s3lfs.manifest["files"]["data.bin"] = h
+                s3lfs.save_manifest()
+
+            result = s3lfs._prepare_file_for_upload("data.bin")
+            self.assertIsNone(result)
+
+    def test_chunk_has_correct_s3_key(self):
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+            s3lfs = S3LFS(bucket_name="test-bucket")
+
+            Path("file.txt").write_bytes(b"data")
+            result = s3lfs._prepare_file_for_upload("file.txt")
+
+            _, file_hash, chunks = result
+            expected_key = f"pfx/assets/{file_hash}/file.txt.gz"
+            self.assertEqual(chunks[0]["s3_key"], expected_key)
+
+
+class TestUploadChunk(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "pfx",
+            "files": {},
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_uploads_and_cleans_up(self):
+        with patch("boto3.client") as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.return_value = mock_client
+            mock_client.upload_fileobj = Mock()
+
+            s3lfs = S3LFS(bucket_name="test-bucket")
+
+            chunk_path = Path(self.temp_dir) / "chunk.gz"
+            chunk_path.write_bytes(b"compressed data")
+
+            chunk_info = {
+                "path": chunk_path,
+                "s3_key": "pfx/assets/h/file.gz",
+                "chunk_index": 0,
+                "extra_args": {},
+            }
+
+            s3_key, bytes_uploaded = s3lfs._upload_chunk(chunk_info)
+
+            self.assertEqual(s3_key, "pfx/assets/h/file.gz")
+            self.assertEqual(bytes_uploaded, 15)
+            mock_client.upload_fileobj.assert_called_once()
+            # Chunk file should be cleaned up
+            self.assertFalse(chunk_path.exists())
+
+
+class TestParallelUploadChunked(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+
+        manifest = {
+            "bucket_name": "test-bucket",
+            "repo_prefix": "pfx",
+            "files": {},
+        }
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(manifest, f)
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_empty_file_list(self):
+        with patch("boto3.client") as mock_boto3:
+            mock_boto3.return_value = Mock()
+            s3lfs = S3LFS(bucket_name="test-bucket")
+            s3lfs.parallel_upload_chunked([], silence=True)
+
+    def test_uploads_multiple_files(self):
+        with patch("boto3.client") as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.return_value = mock_client
+            mock_client.upload_fileobj = Mock()
+            mock_client.head_object.return_value = {"ContentLength": 10}
+
+            s3lfs = S3LFS(bucket_name="test-bucket")
+
+            Path("a.txt").write_bytes(b"file a content")
+            Path("b.txt").write_bytes(b"file b content")
+
+            s3lfs.parallel_upload_chunked(["a.txt", "b.txt"], silence=True)
+
+            # Both files should have been uploaded
+            self.assertEqual(mock_client.upload_fileobj.call_count, 2)
+
+            # Manifest should be updated
+            self.assertIn("a.txt", s3lfs.manifest["files"])
+            self.assertIn("b.txt", s3lfs.manifest["files"])
+
+    def test_skips_unchanged_files(self):
+        with patch("boto3.client") as mock_boto3:
+            mock_client = Mock()
+            mock_boto3.return_value = mock_client
+            mock_client.upload_fileobj = Mock()
+
+            s3lfs = S3LFS(bucket_name="test-bucket")
+
+            Path("a.txt").write_bytes(b"content")
+            h = s3lfs.hash_file("a.txt")
+            with s3lfs._lock_context():
+                s3lfs.manifest["files"]["a.txt"] = h
+                s3lfs.save_manifest()
+
+            s3lfs.parallel_upload_chunked(["a.txt"], silence=True)
+
+            # No upload should have happened
+            mock_client.upload_fileobj.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

The upload path now uses the same producer-consumer pattern as the download side (#58). File preparation (hash + compress + split) and chunk uploads share a single thread pool. As each file is prepared, its chunk upload tasks are submitted immediately rather than waiting for all files to finish compressing.

**Before:** Files upload in parallel, but each file's chunks upload sequentially. A 20GB file with 4 chunks blocks one worker for the entire duration.

**After:** Preparation and chunk uploads share a flat pool. While one file is compressing, another file's chunks are uploading.

### New methods

- `_prepare_file_for_upload(file_path)` -- hash, compress, split into chunk dicts. Returns None if hash matches manifest (skip).
- `_upload_chunk(chunk_info)` -- upload a single chunk to S3 and clean up its temp file.
- `parallel_upload_chunked(files)` -- producer-consumer orchestrator with dynamic progress bar.

`parallel_upload` now delegates to `parallel_upload_chunked`. Manifest updates are batched at the end in a single lock acquisition.

## Test plan

- [x] 7 new tests in `test_parallel_upload.py`:
  - `_prepare_file_for_upload`: returns chunks for new file, None for unchanged, correct S3 key
  - `_upload_chunk`: uploads and cleans up temp file
  - `parallel_upload_chunked`: empty list, multiple files, skips unchanged
- [x] All 82 existing tests still pass

Closes #61

Generated with [Claude Code](https://claude.com/claude-code)