### PR TITLE
Stop the hash cache returning a hash matching no version of a file

### DIFF
--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -461,9 +461,12 @@ class S3LFS:
 
     def save_manifest(self):
         """Save the manifest back to disk atomically (YAML or JSON format)."""
-        temp_file = self.manifest_file.with_suffix(
-            ".tmp"
-        )  # Temporary file in the same directory
+        # Unique temp name. A shared one lets two writers interleave into the
+        # same file before either renames: the rename is atomic, the content
+        # is not.
+        temp_file = self.manifest_file.with_name(
+            f"{self.manifest_file.name}.{uuid4().hex}.tmp"
+        )
         try:
             # Write the manifest to a temporary file
             with open(temp_file, "w") as f:
@@ -533,7 +536,10 @@ class S3LFS:
         if hasattr(self, "_cache_dirty") and not self._cache_dirty:
             return
 
-        temp_file = self.cache_file.with_suffix(".tmp")
+        # Unique temp name; see save_manifest.
+        temp_file = self.cache_file.with_name(
+            f"{self.cache_file.name}.{uuid4().hex}.tmp"
+        )
         try:
             with open(temp_file, "w") as f:
                 if self.cache_file.suffix in [".yaml", ".yml"]:
@@ -595,6 +601,42 @@ class S3LFS:
         else:
             raise ValueError(f"Unsupported hashing method: {method}")
 
+    # Filesystem mtime is frequently stored at 1-second resolution. A file
+    # modified within this window of being hashed cannot be distinguished from
+    # one that was not, so such entries are not cached at all.
+    MTIME_GRANULARITY_SECONDS = 1.0
+
+    def _changed_during_hashing(self, file_path, metadata):
+        """Did the file change between the pre-hash stat and now?"""
+        try:
+            stat = Path(file_path).stat()
+        except OSError:
+            return True
+
+        return (
+            stat.st_size != metadata["size"]
+            or stat.st_mtime != metadata["mtime"]
+            or getattr(stat, "st_ino", None) != metadata["inode"]
+        )
+
+    def _entry_is_racy(self, cached_data):
+        """Was this entry written too soon after the file was modified?
+
+        If the gap between the file's mtime and the moment we recorded the
+        hash is below mtime granularity, a further modification in that same
+        tick would leave (size, mtime, inode) unchanged and go unnoticed. Such
+        an entry cannot be trusted on the strength of its metadata alone.
+
+        The entry is still kept: recomputing once refreshes it with a
+        timestamp comfortably after the mtime, and it is trusted from then on.
+        This mirrors git's "racily clean" handling.
+        """
+        written_at = cached_data.get("timestamp")
+        mtime = cached_data.get("metadata", {}).get("mtime")
+        if written_at is None or mtime is None:
+            return True
+        return (written_at - mtime) < self.MTIME_GRANULARITY_SECONDS
+
     def hash_file_cached(
         self, file_path: Union[str, Path], method: str = "auto"
     ) -> str:
@@ -639,6 +681,7 @@ class S3LFS:
                     cached_metadata.get("size") == current_metadata["size"]
                     and cached_metadata.get("mtime") == current_metadata["mtime"]
                     and cached_metadata.get("inode") == current_metadata["inode"]
+                    and not self._entry_is_racy(cached_data)
                 ):
                     # File hasn't changed, return cached hash
                     return cached_data["hash"]
@@ -649,6 +692,13 @@ class S3LFS:
 
         # Compute hash outside of lock to avoid blocking other processes
         new_hash = self.hash_file(file_path, method)
+
+        # The metadata above was read before hashing. If the file changed while
+        # we were reading it, that hash belongs to no single version of the
+        # file, and storing it against the pre-hash metadata would leave an
+        # entry that is wrong whenever those metadata recur.
+        if self._changed_during_hashing(file_path, current_metadata):
+            return new_hash
 
         # Acquire lock again to update cache
         with self._lock_context():
@@ -663,6 +713,7 @@ class S3LFS:
                     cached_metadata.get("size") == current_metadata["size"]
                     and cached_metadata.get("mtime") == current_metadata["mtime"]
                     and cached_metadata.get("inode") == current_metadata["inode"]
+                    and not self._entry_is_racy(cached_data)
                 ):
                     # Another process computed it while we were working
                     return cached_data["hash"]

--- a/tests/test_hash_cache_safety.py
+++ b/tests/test_hash_cache_safety.py
@@ -1,0 +1,173 @@
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from s3lfs.core import S3LFS
+
+
+class TestHashCacheSafety(unittest.TestCase):
+    """The hash cache must never return a hash matching no version of a file.
+
+    The cache key is (size, mtime, inode). Metadata was read before hashing
+    and stored alongside the result afterwards, so a file modified during
+    hashing produced an entry whose hash belonged to neither the old nor the
+    new content. Filesystem mtime is also often 1-second granular, so a file
+    modified within the same second can be indistinguishable from an
+    unmodified one.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        self.root = Path(self.temp_dir).resolve()
+        os.makedirs(".git")
+
+        self.manifest_path = self.root / ".s3_manifest.yaml"
+        with open(self.manifest_path, "w") as f:
+            yaml.safe_dump(
+                {
+                    "bucket_name": "test-bucket",
+                    "repo_prefix": "test-prefix",
+                    "files": {},
+                },
+                f,
+            )
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _s3lfs(self):
+        with patch("boto3.client"):
+            return S3LFS(
+                bucket_name="test-bucket",
+                manifest_file=str(self.manifest_path),
+                s3_factory=lambda no_sign: MagicMock(),
+            )
+
+    def _settled_file(self, name, content):
+        """A file old enough that mtime is decisive."""
+        path = Path(name)
+        path.write_bytes(content)
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        return path
+
+    def test_file_changed_during_hashing_is_not_cached(self):
+        s3lfs = self._s3lfs()
+        path = self._settled_file("racy.bin", b"original")
+
+        real_hash_file = s3lfs.hash_file
+
+        def hash_and_mutate(file_path, method="auto"):
+            result = real_hash_file(file_path, method)
+            # The file changes while we are hashing it.
+            Path(file_path).write_bytes(b"modified during hashing")
+            return result
+
+        with patch.object(s3lfs, "hash_file", side_effect=hash_and_mutate):
+            s3lfs.hash_file_cached(path)
+
+        self.assertNotIn(
+            str(path.as_posix()),
+            s3lfs.hash_cache,
+            "a hash computed over a file being modified was cached",
+        )
+
+    def test_racy_entry_is_stored_but_not_trusted(self):
+        """A file hashed within mtime granularity must be revalidated.
+
+        The entry is still written — refusing to cache would make the cache
+        useless for the common case of tracking files just after writing them
+        — but it is recomputed once rather than trusted on metadata alone.
+        """
+        s3lfs = self._s3lfs()
+        path = Path("fresh.bin")
+        path.write_bytes(b"just written")
+
+        s3lfs.hash_file_cached(path)
+        entry = s3lfs.hash_cache[str(path.as_posix())]
+
+        self.assertTrue(s3lfs._entry_is_racy(entry))
+
+        # A racy entry must not be served from metadata alone.
+        recomputed = []
+        real_hash_file = s3lfs.hash_file
+
+        def counting(file_path, method="auto"):
+            recomputed.append(file_path)
+            return real_hash_file(file_path, method)
+
+        with patch.object(s3lfs, "hash_file", side_effect=counting):
+            s3lfs.hash_file_cached(path)
+
+        self.assertEqual(len(recomputed), 1, "racy entry was trusted without a rehash")
+
+    def test_racy_entry_becomes_trusted_after_revalidation(self):
+        """Revalidating once must settle the entry, not loop forever."""
+        s3lfs = self._s3lfs()
+        path = Path("settling.bin")
+        path.write_bytes(b"content")
+
+        s3lfs.hash_file_cached(path)  # racy
+        # Once the file's mtime is comfortably in the past, the refreshed
+        # entry is trustworthy.
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        s3lfs.hash_file_cached(path)  # recompute, store non-racy
+
+        with patch.object(s3lfs, "hash_file", side_effect=AssertionError("recomputed")):
+            s3lfs.hash_file_cached(path)
+
+    def test_settled_file_is_cached_and_reused(self):
+        s3lfs = self._s3lfs()
+        path = self._settled_file("stable.bin", b"stable content")
+
+        first = s3lfs.hash_file_cached(path)
+        self.assertIn(str(path.as_posix()), s3lfs.hash_cache)
+
+        # A second call must not recompute.
+        with patch.object(s3lfs, "hash_file", side_effect=AssertionError("recomputed")):
+            second = s3lfs.hash_file_cached(path)
+
+        self.assertEqual(first, second)
+
+    def test_cached_hash_matches_actual_content(self):
+        s3lfs = self._s3lfs()
+        path = self._settled_file("verify.bin", b"content to verify")
+
+        cached = s3lfs.hash_file_cached(path)
+        direct = s3lfs.hash_file(path)
+
+        self.assertEqual(cached, direct)
+
+    def test_manifest_temp_file_name_is_unique(self):
+        """Concurrent writers must not share one temp file."""
+        a = self._s3lfs()
+        b = self._s3lfs()
+
+        names = set()
+        real_replace = Path.replace
+
+        def capture(self_path, target):
+            names.add(self_path.name)
+            return real_replace(self_path, target)
+
+        with patch.object(Path, "replace", capture):
+            with a._lock_context():
+                a.save_manifest()
+            with b._lock_context():
+                b.save_manifest()
+
+        self.assertEqual(len(names), 2, f"temp file name was reused: {names}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #90. Stacked on #94.

Three related defects in the `(size, mtime, inode)` hash cache.

## 1. Metadata captured before hashing

File metadata was read *before* computing the hash and stored alongside the result *after*. A file modified during hashing produced an entry whose hash belonged to neither the old nor the new content — and which would be served again whenever those metadata recurred.

The file is now re-stat'd after hashing and the entry dropped if anything moved.

## 2. mtime granularity

Filesystem mtime is frequently 1-second granular, so a file modified within the same tick as it was hashed is indistinguishable from one that was not.

Such entries are now marked **racy** and revalidated rather than trusted on metadata alone.

### The design detail worth reviewing

My first attempt simply refused to cache recently-modified files. That is wrong, and the existing suite said so — it broke five cache tests. Tracking files immediately after writing them is the *primary* workflow, so never caching within the racy window makes the cache useless exactly when it matters.

The entry is therefore still written. Recomputing once refreshes it with a timestamp comfortably after the mtime, and it is trusted from then on — one extra hash per file, once, rather than either a wrong answer or a permanently cold cache. This mirrors git's racily-clean handling.

`test_racy_entry_becomes_trusted_after_revalidation` pins the self-healing, since "revalidate" that never settles would be a silent performance cliff.

## 3. Shared temp filenames

Both `save_manifest` and `save_cache` wrote through a fixed temp name (`.s3_manifest.tmp`). The rename is atomic; the content is not. Two writers interleave into the same temp file before either renames, so the surviving file can be a byte-level mix of two documents. Both now use unique temp names.

## Verification

Three of the six new tests fail on the parent commit.

`61 failed / 549 passed` → `61 failed / 555 passed`, failure set identical. The 61 are the missing-`python`-binary failures fixed separately in #93.

## Not addressed

`load_cache` skips reading when the on-disk mtime matches what it last wrote, so two processes saving within one mtime tick can still lose an update — the same shape as the manifest read-modify-write bug, in the cache. It needs the same treatment and is not attempted here. `cleanup_stale_cache` also still exists and is never called from the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UrDtdFKGwQZp8oYGwL2rj