### PR TITLE
Fix path normalization in remove, off-thread construction, and a docstring

### DIFF
--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -461,9 +461,12 @@ class S3LFS:
 
     def save_manifest(self):
         """Save the manifest back to disk atomically (YAML or JSON format)."""
-        temp_file = self.manifest_file.with_suffix(
-            ".tmp"
-        )  # Temporary file in the same directory
+        # Unique temp name. A shared one lets two writers interleave into the
+        # same file before either renames: the rename is atomic, the content
+        # is not.
+        temp_file = self.manifest_file.with_name(
+            f"{self.manifest_file.name}.{uuid4().hex}.tmp"
+        )
         try:
             # Write the manifest to a temporary file
             with open(temp_file, "w") as f:
@@ -533,7 +536,10 @@ class S3LFS:
         if hasattr(self, "_cache_dirty") and not self._cache_dirty:
             return
 
-        temp_file = self.cache_file.with_suffix(".tmp")
+        # Unique temp name; see save_manifest.
+        temp_file = self.cache_file.with_name(
+            f"{self.cache_file.name}.{uuid4().hex}.tmp"
+        )
         try:
             with open(temp_file, "w") as f:
                 if self.cache_file.suffix in [".yaml", ".yml"]:
@@ -595,6 +601,42 @@ class S3LFS:
         else:
             raise ValueError(f"Unsupported hashing method: {method}")
 
+    # Filesystem mtime is frequently stored at 1-second resolution. A file
+    # modified within this window of being hashed cannot be distinguished from
+    # one that was not, so such entries are not cached at all.
+    MTIME_GRANULARITY_SECONDS = 1.0
+
+    def _changed_during_hashing(self, file_path, metadata):
+        """Did the file change between the pre-hash stat and now?"""
+        try:
+            stat = Path(file_path).stat()
+        except OSError:
+            return True
+
+        return (
+            stat.st_size != metadata["size"]
+            or stat.st_mtime != metadata["mtime"]
+            or getattr(stat, "st_ino", None) != metadata["inode"]
+        )
+
+    def _entry_is_racy(self, cached_data):
+        """Was this entry written too soon after the file was modified?
+
+        If the gap between the file's mtime and the moment we recorded the
+        hash is below mtime granularity, a further modification in that same
+        tick would leave (size, mtime, inode) unchanged and go unnoticed. Such
+        an entry cannot be trusted on the strength of its metadata alone.
+
+        The entry is still kept: recomputing once refreshes it with a
+        timestamp comfortably after the mtime, and it is trusted from then on.
+        This mirrors git's "racily clean" handling.
+        """
+        written_at = cached_data.get("timestamp")
+        mtime = cached_data.get("metadata", {}).get("mtime")
+        if written_at is None or mtime is None:
+            return True
+        return (written_at - mtime) < self.MTIME_GRANULARITY_SECONDS
+
     def hash_file_cached(
         self, file_path: Union[str, Path], method: str = "auto"
     ) -> str:
@@ -639,6 +681,7 @@ class S3LFS:
                     cached_metadata.get("size") == current_metadata["size"]
                     and cached_metadata.get("mtime") == current_metadata["mtime"]
                     and cached_metadata.get("inode") == current_metadata["inode"]
+                    and not self._entry_is_racy(cached_data)
                 ):
                     # File hasn't changed, return cached hash
                     return cached_data["hash"]
@@ -649,6 +692,13 @@ class S3LFS:
 
         # Compute hash outside of lock to avoid blocking other processes
         new_hash = self.hash_file(file_path, method)
+
+        # The metadata above was read before hashing. If the file changed while
+        # we were reading it, that hash belongs to no single version of the
+        # file, and storing it against the pre-hash metadata would leave an
+        # entry that is wrong whenever those metadata recur.
+        if self._changed_during_hashing(file_path, current_metadata):
+            return new_hash
 
         # Acquire lock again to update cache
         with self._lock_context():
@@ -663,6 +713,7 @@ class S3LFS:
                     cached_metadata.get("size") == current_metadata["size"]
                     and cached_metadata.get("mtime") == current_metadata["mtime"]
                     and cached_metadata.get("inode") == current_metadata["inode"]
+                    and not self._entry_is_racy(cached_data)
                 ):
                     # Another process computed it while we were working
                     return cached_data["hash"]

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -252,7 +252,14 @@ class S3LFS:
             self.path_resolver = PathResolver(manifest_dir)
 
         self._shutdown_requested = False
-        signal.signal(signal.SIGINT, self._handle_sigint)
+        # signal.signal only works on the main thread of the main interpreter,
+        # and raises ValueError elsewhere. Constructing an S3LFS from a worker
+        # thread is legitimate for library callers, so treat the handler as
+        # best-effort rather than a hard requirement.
+        try:
+            signal.signal(signal.SIGINT, self._handle_sigint)
+        except ValueError:
+            pass
 
     def _handle_sigint(self, signum, frame):
         """
@@ -564,8 +571,11 @@ class S3LFS:
 
     def hash_file(self, file_path: Union[str, Path], method: str = "auto") -> str:
         """
-        Compute a unique SHA-256 hash of the file using its content and relative path.
-        Supports multiple hashing methods for performance optimization.
+        Compute a SHA-256 hash of the file's contents.
+
+        The hash covers content only: the same bytes at two different paths
+        produce the same digest. Supports multiple hashing methods for
+        performance optimization.
 
         :param file_path: Path to the file to hash.
         :param method: Hashing method to use. Options are:
@@ -1405,7 +1415,10 @@ class S3LFS:
         :param keep_in_s3: If False, schedule the file for deletion in future GC.
         """
         file_path = Path(file_path)
-        file_path_str = str(file_path.as_posix())
+        # Normalise the same way every other call site does. Using the raw
+        # argument meant "./data/x.bin" or an absolute path reported the file
+        # as untracked when it was tracked under "data/x.bin".
+        file_path_str = self._get_manifest_key(file_path)
 
         with self._lock_context():
             # Re-read under the lock: this process's copy may predate another
@@ -1423,12 +1436,14 @@ class S3LFS:
         print(f"Removed tracking for '{file_path}'.")
 
         if not keep_in_s3:
-            s3_key = f"{self.repo_prefix}/assets/{file_hash}/{file_path.as_posix()}.gz"
+            # Objects are stored under the manifest key, so deletion must use
+            # it too; the raw argument would miss the object entirely.
+            s3_key = f"{self.repo_prefix}/assets/{file_hash}/{file_path_str}.gz"
             self._get_s3_client().delete_object(Bucket=self.bucket_name, Key=s3_key)
             print(f"File removed from S3: s3://{self.bucket_name}/{s3_key}")
         else:
             print(
-                f"File remains in S3: s3://{self.bucket_name}/{file_hash}/{file_path.as_posix()}"
+                f"File remains in S3: s3://{self.bucket_name}/{file_hash}/{file_path_str}"
             )
 
     def cleanup_s3(self, force=False):

--- a/tests/test_hash_cache_safety.py
+++ b/tests/test_hash_cache_safety.py
@@ -1,0 +1,173 @@
+import os
+import shutil
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from s3lfs.core import S3LFS
+
+
+class TestHashCacheSafety(unittest.TestCase):
+    """The hash cache must never return a hash matching no version of a file.
+
+    The cache key is (size, mtime, inode). Metadata was read before hashing
+    and stored alongside the result afterwards, so a file modified during
+    hashing produced an entry whose hash belonged to neither the old nor the
+    new content. Filesystem mtime is also often 1-second granular, so a file
+    modified within the same second can be indistinguishable from an
+    unmodified one.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        self.root = Path(self.temp_dir).resolve()
+        os.makedirs(".git")
+
+        self.manifest_path = self.root / ".s3_manifest.yaml"
+        with open(self.manifest_path, "w") as f:
+            yaml.safe_dump(
+                {
+                    "bucket_name": "test-bucket",
+                    "repo_prefix": "test-prefix",
+                    "files": {},
+                },
+                f,
+            )
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _s3lfs(self):
+        with patch("boto3.client"):
+            return S3LFS(
+                bucket_name="test-bucket",
+                manifest_file=str(self.manifest_path),
+                s3_factory=lambda no_sign: MagicMock(),
+            )
+
+    def _settled_file(self, name, content):
+        """A file old enough that mtime is decisive."""
+        path = Path(name)
+        path.write_bytes(content)
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        return path
+
+    def test_file_changed_during_hashing_is_not_cached(self):
+        s3lfs = self._s3lfs()
+        path = self._settled_file("racy.bin", b"original")
+
+        real_hash_file = s3lfs.hash_file
+
+        def hash_and_mutate(file_path, method="auto"):
+            result = real_hash_file(file_path, method)
+            # The file changes while we are hashing it.
+            Path(file_path).write_bytes(b"modified during hashing")
+            return result
+
+        with patch.object(s3lfs, "hash_file", side_effect=hash_and_mutate):
+            s3lfs.hash_file_cached(path)
+
+        self.assertNotIn(
+            str(path.as_posix()),
+            s3lfs.hash_cache,
+            "a hash computed over a file being modified was cached",
+        )
+
+    def test_racy_entry_is_stored_but_not_trusted(self):
+        """A file hashed within mtime granularity must be revalidated.
+
+        The entry is still written — refusing to cache would make the cache
+        useless for the common case of tracking files just after writing them
+        — but it is recomputed once rather than trusted on metadata alone.
+        """
+        s3lfs = self._s3lfs()
+        path = Path("fresh.bin")
+        path.write_bytes(b"just written")
+
+        s3lfs.hash_file_cached(path)
+        entry = s3lfs.hash_cache[str(path.as_posix())]
+
+        self.assertTrue(s3lfs._entry_is_racy(entry))
+
+        # A racy entry must not be served from metadata alone.
+        recomputed = []
+        real_hash_file = s3lfs.hash_file
+
+        def counting(file_path, method="auto"):
+            recomputed.append(file_path)
+            return real_hash_file(file_path, method)
+
+        with patch.object(s3lfs, "hash_file", side_effect=counting):
+            s3lfs.hash_file_cached(path)
+
+        self.assertEqual(len(recomputed), 1, "racy entry was trusted without a rehash")
+
+    def test_racy_entry_becomes_trusted_after_revalidation(self):
+        """Revalidating once must settle the entry, not loop forever."""
+        s3lfs = self._s3lfs()
+        path = Path("settling.bin")
+        path.write_bytes(b"content")
+
+        s3lfs.hash_file_cached(path)  # racy
+        # Once the file's mtime is comfortably in the past, the refreshed
+        # entry is trustworthy.
+        old = time.time() - 60
+        os.utime(path, (old, old))
+        s3lfs.hash_file_cached(path)  # recompute, store non-racy
+
+        with patch.object(s3lfs, "hash_file", side_effect=AssertionError("recomputed")):
+            s3lfs.hash_file_cached(path)
+
+    def test_settled_file_is_cached_and_reused(self):
+        s3lfs = self._s3lfs()
+        path = self._settled_file("stable.bin", b"stable content")
+
+        first = s3lfs.hash_file_cached(path)
+        self.assertIn(str(path.as_posix()), s3lfs.hash_cache)
+
+        # A second call must not recompute.
+        with patch.object(s3lfs, "hash_file", side_effect=AssertionError("recomputed")):
+            second = s3lfs.hash_file_cached(path)
+
+        self.assertEqual(first, second)
+
+    def test_cached_hash_matches_actual_content(self):
+        s3lfs = self._s3lfs()
+        path = self._settled_file("verify.bin", b"content to verify")
+
+        cached = s3lfs.hash_file_cached(path)
+        direct = s3lfs.hash_file(path)
+
+        self.assertEqual(cached, direct)
+
+    def test_manifest_temp_file_name_is_unique(self):
+        """Concurrent writers must not share one temp file."""
+        a = self._s3lfs()
+        b = self._s3lfs()
+
+        names = set()
+        real_replace = Path.replace
+
+        def capture(self_path, target):
+            names.add(self_path.name)
+            return real_replace(self_path, target)
+
+        with patch.object(Path, "replace", capture):
+            with a._lock_context():
+                a.save_manifest()
+            with b._lock_context():
+                b.save_manifest()
+
+        self.assertEqual(len(names), 2, f"temp file name was reused: {names}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_path_normalization.py
+++ b/tests/test_path_normalization.py
@@ -1,0 +1,183 @@
+import hashlib
+import os
+import shutil
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from s3lfs.core import S3LFS
+
+
+class TestRemoveFilePathNormalization(unittest.TestCase):
+    """`remove` must accept the same path spellings as every other command.
+
+    Manifest keys are relative to the git root. remove_file built its key
+    from the raw argument, so equivalent spellings of a tracked path were
+    reported as untracked.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        self.root = Path(self.temp_dir).resolve()
+        os.makedirs(".git")
+        os.makedirs("data")
+        Path("data/asset.bin").write_bytes(b"payload")
+
+        self.manifest_path = self.root / ".s3_manifest.yaml"
+        with open(self.manifest_path, "w") as f:
+            yaml.safe_dump(
+                {
+                    "bucket_name": "test-bucket",
+                    "repo_prefix": "test-prefix",
+                    "files": {"data/asset.bin": "abc123"},
+                },
+                f,
+            )
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _s3lfs(self):
+        with patch("boto3.client"):
+            return S3LFS(
+                bucket_name="test-bucket",
+                manifest_file=str(self.manifest_path),
+                s3_factory=lambda no_sign: MagicMock(),
+            )
+
+    def _tracked(self):
+        with open(self.manifest_path) as f:
+            return yaml.safe_load(f)["files"]
+
+    def test_removes_with_plain_relative_path(self):
+        s3lfs = self._s3lfs()
+        s3lfs.remove_file("data/asset.bin")
+        self.assertNotIn("data/asset.bin", self._tracked())
+
+    def test_removes_with_dot_slash_prefix(self):
+        s3lfs = self._s3lfs()
+        s3lfs.remove_file("./data/asset.bin")
+        self.assertNotIn("data/asset.bin", self._tracked())
+
+    def test_removes_with_absolute_path(self):
+        s3lfs = self._s3lfs()
+        s3lfs.remove_file(str(self.root / "data" / "asset.bin"))
+        self.assertNotIn("data/asset.bin", self._tracked())
+
+    def test_deletes_the_object_actually_stored(self):
+        """The S3 key must match how the object was uploaded."""
+        deleted = []
+
+        def factory(no_sign_request):
+            client = MagicMock()
+            client.delete_object.side_effect = lambda Bucket=None, Key=None, **kw: (
+                deleted.append(Key)
+            )
+            return client
+
+        with patch("boto3.client"):
+            s3lfs = S3LFS(
+                bucket_name="test-bucket",
+                manifest_file=str(self.manifest_path),
+                s3_factory=factory,
+            )
+
+        s3lfs.remove_file("./data/asset.bin", keep_in_s3=False)
+
+        self.assertEqual(deleted, ["test-prefix/assets/abc123/data/asset.bin.gz"])
+
+
+class TestConstructionOffMainThread(unittest.TestCase):
+    """S3LFS must be constructible from a worker thread.
+
+    signal.signal raises ValueError off the main thread, which made the
+    class unusable as a library component inside one.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(
+                {
+                    "bucket_name": "test-bucket",
+                    "repo_prefix": "test-prefix",
+                    "files": {},
+                },
+                f,
+            )
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_constructs_in_worker_thread(self):
+        result: dict = {}
+
+        def build():
+            try:
+                with patch("boto3.client"):
+                    result["obj"] = S3LFS(
+                        bucket_name="test-bucket",
+                        s3_factory=lambda no_sign: MagicMock(),
+                    )
+            except Exception as exc:  # pragma: no cover - failure path
+                result["error"] = exc
+
+        thread = threading.Thread(target=build)
+        thread.start()
+        thread.join(timeout=30)
+
+        self.assertNotIn("error", result, f"construction failed: {result.get('error')}")
+        self.assertIsNotNone(result.get("obj"))
+
+
+class TestHashIsContentOnly(unittest.TestCase):
+    """The documented contract: the digest covers content, not path."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(
+                {
+                    "bucket_name": "test-bucket",
+                    "repo_prefix": "test-prefix",
+                    "files": {},
+                },
+                f,
+            )
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_same_content_different_paths_same_hash(self):
+        with patch("boto3.client"):
+            s3lfs = S3LFS(
+                bucket_name="test-bucket", s3_factory=lambda no_sign: MagicMock()
+            )
+
+        content = b"identical bytes"
+        Path("a.bin").write_bytes(content)
+        os.makedirs("sub")
+        Path("sub/b.bin").write_bytes(content)
+
+        expected = hashlib.sha256(content).hexdigest()
+        self.assertEqual(s3lfs.hash_file("a.bin"), expected)
+        self.assertEqual(s3lfs.hash_file("sub/b.bin"), expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refs #91 — three of its independent items. Stacked on #95.

## `remove` rejected valid paths

`remove_file` built its manifest key from the raw user argument instead of `path_resolver.to_manifest_key()`, which every other call site uses. An absolute path reported a tracked file as **untracked**.

It also built its S3 deletion key from the raw argument, so with `--purge-from-s3` the delete would target a key the object was never stored under — reporting success while leaving the object in place.

Accuracy note: `./data/x.bin` already worked, because `Path.as_posix()` collapses the `./`. Absolute paths were the genuinely broken case. The issue implied both; only one was real.

## Construction failed off the main thread

`__init__` installed a SIGINT handler unconditionally. `signal.signal` only works on the main thread of the main interpreter and raises `ValueError` elsewhere, so `S3LFS(...)` inside a worker thread failed outright:

```
ValueError: signal only works in main thread of the main interpreter
```

Now best-effort, which is the right posture for a library component that doesn't own process-wide signal handling.

## Docstring contradicted behaviour

`hash_file` claimed the digest covers "content and relative path". It is content-only — the same bytes at two paths produce the same digest. The claim implied a path-collision resistance that does not exist, which matters because the storage key embeds both hash and path (see #87).

## Verification

Two of the six new tests fail on the parent commit. `61 failed / 555 passed` → `61 failed / 561 passed`, failure set identical.

## Left in #91

Not addressed here, and the issue stays open for them:

- `_shutdown_requested` is only polled by drain loops, so workers finish in-flight work after an interrupt.
- `max_concurrency` multiplies with the worker pool (up to 256 in-flight parts at `workers=16`).
- Enumeration filtering is subtree-only; an explicitly named internal path still resolves.

The `cleanup_s3` unanchored-`str.replace` item was already fixed in #94, which needed correct key parsing for its re-validation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UrDtdFKGwQZp8oYGwL2rj