### PR TITLE
Make garbage collection reachability path-aware

### DIFF
--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -314,40 +314,87 @@ class S3LFS:
             yaml.safe_dump({"claims": claims}, f)
         temp_file.replace(self._inflight_file)
 
-    def _live_inflight_hashes(self):
+    def _live_inflight_keys(self):
         """Claims that have not aged out. Caller must hold the lock."""
         cutoff = time.time() - self.INFLIGHT_TTL_SECONDS
-        return {h for h, ts in self._load_inflight().items() if ts >= cutoff}
+        return {k for k, ts in self._load_inflight().items() if ts >= cutoff}
 
-    def _claim_inflight(self, file_hash):
-        """Register a hash as in-flight, before any of its bytes reach S3."""
+    def _claim_inflight(self, base_key):
+        """Register an asset key as in-flight, before any bytes reach S3."""
         with self._lock_context():
             claims = self._load_inflight()
-            claims[file_hash] = time.time()
+            claims[base_key] = time.time()
             self._save_inflight(claims)
 
-    def _release_inflight(self, hashes):
+    def _release_inflight(self, base_keys):
         """Drop claims. Must run only after the manifest entry is published."""
-        if not hashes:
+        if not base_keys:
             return
         with self._lock_context():
             claims = self._load_inflight()
             cutoff = time.time() - self.INFLIGHT_TTL_SECONDS
             claims = {
-                h: ts
-                for h, ts in claims.items()
-                if h not in hashes and ts >= cutoff  # also prune aged-out claims
+                k: ts
+                for k, ts in claims.items()
+                if k not in base_keys and ts >= cutoff  # also prune aged-out claims
             }
             self._save_inflight(claims)
 
-    def _hash_from_asset_key(self, key):
-        """Extract the content hash from an assets/ S3 key, or None."""
+    def _asset_base_key(self, manifest_key, file_hash):
+        """The S3 key a file's content is stored under."""
+        return f"{self.repo_prefix}/assets/{file_hash}/{manifest_key}.gz"
+
+    def _delete_asset(self, base_key):
+        """Delete an asset and every chunk belonging to it.
+
+        A large file is stored as base_key.chunk0..N rather than at base_key
+        itself, so deleting only the base key leaves the whole file behind.
+        """
+        client = self._get_s3_client()
+        resp = client.list_objects_v2(Bucket=self.bucket_name, Prefix=base_key)
+        keys = [obj["Key"] for obj in resp.get("Contents", [])]
+        # Guard against a prefix match on an unrelated, longer key.
+        keys = [k for k in keys if self._key_covered_by(k, {base_key})]
+        if not keys:
+            keys = [base_key]
+
+        for key in keys:
+            client.delete_object(Bucket=self.bucket_name, Key=key)
+            print(f"File removed from S3: s3://{self.bucket_name}/{key}")
+
+    def _live_asset_keys(self):
+        """Base keys reachable from the manifest. Caller must hold the lock."""
+        return {
+            self._asset_base_key(manifest_key, file_hash)
+            for manifest_key, file_hash in self.manifest.get("files", {}).items()
+        }
+
+    def _is_asset_key(self, key):
+        """Does this key have the shape of a stored asset?
+
+        Anything else under the prefix is left alone: s3lfs did not put it
+        there in a form it recognises, so it is not ours to delete.
+        """
         prefix = f"{self.repo_prefix}/assets/"
         if not key.startswith(prefix):
-            return None
+            return False
         rest = key[len(prefix) :]
-        head, _, tail = rest.partition("/")
-        return head if tail else None
+        head, sep, tail = rest.partition("/")
+        return bool(head and sep and tail)
+
+    @staticmethod
+    def _key_covered_by(key, base_keys):
+        """Is this key one of these assets, or a chunk belonging to one?
+
+        Reachability has to be judged on hash *and* path, because that is what
+        the storage layout keys on. Judging on the hash alone means an object
+        stays reachable as long as any path shares its content, so a removed
+        or renamed path leaks its object permanently.
+        """
+        if key in base_keys:
+            return True
+        head, sep, tail = key.rpartition(".chunk")
+        return bool(sep) and tail.isdigit() and head in base_keys
 
     def _get_s3_client(self):
         """Ensures each thread gets its own instance of the S3 client with appropriate authentication handling."""
@@ -1438,9 +1485,7 @@ class S3LFS:
         if not keep_in_s3:
             # Objects are stored under the manifest key, so deletion must use
             # it too; the raw argument would miss the object entirely.
-            s3_key = f"{self.repo_prefix}/assets/{file_hash}/{file_path_str}.gz"
-            self._get_s3_client().delete_object(Bucket=self.bucket_name, Key=s3_key)
-            print(f"File removed from S3: s3://{self.bucket_name}/{s3_key}")
+            self._delete_asset(self._asset_base_key(file_path_str, file_hash))
         else:
             print(
                 f"File remains in S3: s3://{self.bucket_name}/{file_hash}/{file_path_str}"
@@ -1454,8 +1499,7 @@ class S3LFS:
         """
         with self._lock_context():
             self.load_manifest()
-            live_hashes = set(self.manifest["files"].values())
-            live_hashes |= self._live_inflight_hashes()
+            live_keys = self._live_asset_keys() | self._live_inflight_keys()
 
         paginator = self._get_s3_client().get_paginator("list_objects_v2")
         pages = paginator.paginate(
@@ -1468,12 +1512,11 @@ class S3LFS:
             if "Contents" in page:
                 for obj in page["Contents"]:
                     key = obj["Key"]
-                    file_hash = self._hash_from_asset_key(key)
-                    if file_hash is None:
+                    if not self._is_asset_key(key):
                         continue
 
                     # Collect unreferenced files
-                    if file_hash not in live_hashes:
+                    if not self._key_covered_by(key, live_keys):
                         unreferenced_files.append(key)
 
         if not unreferenced_files:
@@ -1491,15 +1534,14 @@ class S3LFS:
 
         # Re-check under the lock immediately before deleting. Listing S3 and
         # waiting for confirmation both take unbounded time, during which an
-        # upload may have claimed or published any of these hashes.
+        # upload may have claimed or published any of these keys.
         with self._lock_context():
             self.load_manifest()
-            live_now = set(self.manifest["files"].values())
-            live_now |= self._live_inflight_hashes()
+            live_now = self._live_asset_keys() | self._live_inflight_keys()
 
         to_delete = []
         for key in unreferenced_files:
-            if self._hash_from_asset_key(key) in live_now:
+            if self._key_covered_by(key, live_now):
                 print(f"Skipping {key} (became referenced during cleanup)")
                 continue
             to_delete.append(key)
@@ -1666,12 +1708,13 @@ class S3LFS:
 
                         manifest_key, file_hash, chunks = result
 
-                        # Claim the hash before submitting any chunk upload.
+                        # Claim the asset before submitting any chunk upload.
                         # Between a chunk landing in S3 and the manifest entry
                         # being published, the object is unreferenced and a
                         # concurrent cleanup_s3 would otherwise delete it.
-                        self._claim_inflight(file_hash)
-                        claimed.add(file_hash)
+                        base_key = self._asset_base_key(manifest_key, file_hash)
+                        self._claim_inflight(base_key)
+                        claimed.add(base_key)
 
                         pending[manifest_key] = {
                             "hash": file_hash,
@@ -2062,9 +2105,7 @@ class S3LFS:
             for file_path, file_hash in removed_hashes.items():
                 if not file_hash:
                     continue
-                s3_key = f"{self.repo_prefix}/assets/{file_hash}/{file_path}.gz"
-                self._get_s3_client().delete_object(Bucket=self.bucket_name, Key=s3_key)
-                print(f"File removed from S3: s3://{self.bucket_name}/{s3_key}")
+                self._delete_asset(self._asset_base_key(file_path, file_hash))
 
         count = len(files_to_remove)
         print(

--- a/tests/test_gc_inflight.py
+++ b/tests/test_gc_inflight.py
@@ -17,8 +17,8 @@ class TestGCInflightRegistry(unittest.TestCase):
     An uploader PUTs chunks before publishing its manifest entry, so there is
     a window in which an object exists in S3 and nothing references it. A
     sweep running in that window would delete it and leave the manifest
-    pointing at a missing object. Uploaders therefore claim the hash before
-    any bytes are sent, and GC treats claimed hashes as live.
+    pointing at a missing object. Uploaders therefore claim the asset key
+    before any bytes are sent, and GC treats claimed keys as live.
     """
 
     def setUp(self):
@@ -74,12 +74,12 @@ class TestGCInflightRegistry(unittest.TestCase):
                 s3_factory=factory,
             )
 
-    def test_claimed_hash_survives_cleanup(self):
+    def test_claimed_asset_survives_cleanup(self):
         s3lfs = self._s3lfs()
         key = "test-prefix/assets/claimed_hash/file.bin.gz"
         self.store[key] = b"data"
 
-        s3lfs._claim_inflight("claimed_hash")
+        s3lfs._claim_inflight(key)
         s3lfs.cleanup_s3(force=True)
 
         self.assertIn(key, self.store, "GC deleted an in-flight object")
@@ -98,8 +98,8 @@ class TestGCInflightRegistry(unittest.TestCase):
         key = "test-prefix/assets/tmp_hash/file.bin.gz"
         self.store[key] = b"data"
 
-        s3lfs._claim_inflight("tmp_hash")
-        s3lfs._release_inflight({"tmp_hash"})
+        s3lfs._claim_inflight(key)
+        s3lfs._release_inflight({key})
         s3lfs.cleanup_s3(force=True)
 
         self.assertNotIn(key, self.store)
@@ -112,25 +112,28 @@ class TestGCInflightRegistry(unittest.TestCase):
 
         with s3lfs._lock_context():
             expired = time.time() - S3LFS.INFLIGHT_TTL_SECONDS - 60
-            s3lfs._save_inflight({"stale_hash": expired})
+            s3lfs._save_inflight({key: expired})
 
         s3lfs.cleanup_s3(force=True)
 
         self.assertNotIn(key, self.store, "an aged-out claim still pinned an object")
 
-    def test_hash_extracted_from_key_with_prefix_in_path(self):
-        """Key parsing must not be confused by the prefix appearing again."""
+    def test_asset_key_shape_is_validated(self):
+        """Keys that are not recognisably assets are left alone."""
         s3lfs = self._s3lfs()
-        key = "test-prefix/assets/abc123/test-prefix/nested.bin.gz"
 
-        self.assertEqual(s3lfs._hash_from_asset_key(key), "abc123")
-        self.assertIsNone(s3lfs._hash_from_asset_key("other/assets/abc123/f.gz"))
+        self.assertTrue(
+            s3lfs._is_asset_key("test-prefix/assets/abc123/test-prefix/nested.bin.gz")
+        )
+        self.assertFalse(s3lfs._is_asset_key("other/assets/abc123/f.gz"))
+        self.assertFalse(s3lfs._is_asset_key("test-prefix/short"))
+        self.assertFalse(s3lfs._is_asset_key("test-prefix/assets/onlyhash"))
 
     def test_corrupt_registry_does_not_block(self):
         s3lfs = self._s3lfs()
         s3lfs._inflight_file.write_text("{{{ not yaml")
 
-        self.assertEqual(s3lfs._live_inflight_hashes(), set())
+        self.assertEqual(s3lfs._live_inflight_keys(), set())
 
     def test_registry_is_not_enumerated_as_a_user_file(self):
         s3lfs = self._s3lfs()

--- a/tests/test_gc_path_aware.py
+++ b/tests/test_gc_path_aware.py
@@ -1,0 +1,161 @@
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+
+from s3lfs.core import S3LFS
+
+
+class TestPathAwareGC(unittest.TestCase):
+    """Reachability must be judged on hash *and* path.
+
+    Objects are stored at assets/{hash}/{manifest_key}.gz, so the storage
+    unit is hash + path. Garbage collection previously judged reachability on
+    the hash alone, so an object stayed reachable as long as any path shared
+    its content -- a removed or renamed path leaked its object permanently.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        self.root = Path(self.temp_dir).resolve()
+        os.makedirs(".git")
+        self.manifest_path = self.root / ".s3_manifest.yaml"
+        self.store = {}
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _write_manifest(self, files):
+        with open(self.manifest_path, "w") as f:
+            yaml.safe_dump(
+                {
+                    "bucket_name": "test-bucket",
+                    "repo_prefix": "test-prefix",
+                    "files": files,
+                },
+                f,
+            )
+
+    def _s3lfs(self):
+        store = self.store
+
+        def factory(no_sign_request):
+            client = MagicMock()
+
+            def list_objects_v2(Bucket=None, Prefix=None, **kwargs):
+                keys = sorted(k for k in store if k.startswith(Prefix or ""))
+                return {"Contents": [{"Key": k} for k in keys]} if keys else {}
+
+            client.list_objects_v2.side_effect = list_objects_v2
+
+            def get_paginator(_):
+                paginator = MagicMock()
+                paginator.paginate.side_effect = lambda **kw: [list_objects_v2(**kw)]
+                return paginator
+
+            client.get_paginator.side_effect = get_paginator
+            client.delete_object.side_effect = lambda Bucket=None, Key=None, **kw: (
+                store.pop(Key, None)
+            )
+            return client
+
+        with patch("boto3.client"):
+            return S3LFS(
+                bucket_name="test-bucket",
+                manifest_file=str(self.manifest_path),
+                s3_factory=factory,
+            )
+
+    def test_duplicate_content_removed_path_is_collected(self):
+        """Two paths share a hash; removing one must free that path's object."""
+        self._write_manifest({"b/x.bin": "samehash"})
+        removed = "test-prefix/assets/samehash/a/x.bin.gz"
+        kept = "test-prefix/assets/samehash/b/x.bin.gz"
+        self.store[removed] = b"data"
+        self.store[kept] = b"data"
+
+        self._s3lfs().cleanup_s3(force=True)
+
+        self.assertNotIn(removed, self.store, "orphaned duplicate leaked")
+        self.assertIn(kept, self.store, "GC deleted a referenced object")
+
+    def test_renamed_path_object_is_collected(self):
+        self._write_manifest({"new/name.bin": "h1"})
+        stale = "test-prefix/assets/h1/old/name.bin.gz"
+        current = "test-prefix/assets/h1/new/name.bin.gz"
+        self.store[stale] = b"data"
+        self.store[current] = b"data"
+
+        self._s3lfs().cleanup_s3(force=True)
+
+        self.assertNotIn(stale, self.store, "object for the old path leaked")
+        self.assertIn(current, self.store)
+
+    def test_chunks_of_referenced_file_are_kept(self):
+        self._write_manifest({"big.bin": "h2"})
+        base = "test-prefix/assets/h2/big.bin.gz"
+        for i in range(3):
+            self.store[f"{base}.chunk{i}"] = b"chunk"
+
+        self._s3lfs().cleanup_s3(force=True)
+
+        self.assertEqual(len(self.store), 3, "chunks of a tracked file were deleted")
+
+    def test_chunks_of_unreferenced_file_are_collected(self):
+        self._write_manifest({})
+        base = "test-prefix/assets/h3/gone.bin.gz"
+        for i in range(3):
+            self.store[f"{base}.chunk{i}"] = b"chunk"
+
+        self._s3lfs().cleanup_s3(force=True)
+
+        self.assertEqual(self.store, {}, "orphaned chunks were not collected")
+
+    def test_remove_purges_all_chunks(self):
+        self._write_manifest({"big.bin": "h4"})
+        base = "test-prefix/assets/h4/big.bin.gz"
+        for i in range(4):
+            self.store[f"{base}.chunk{i}"] = b"chunk"
+
+        self._s3lfs().remove_file("big.bin", keep_in_s3=False)
+
+        self.assertEqual(self.store, {}, "chunks were left behind by remove")
+
+    def test_inflight_claim_is_path_aware(self):
+        self._write_manifest({})
+        base = "test-prefix/assets/h5/pending.bin.gz"
+        self.store[base] = b"data"
+        other = "test-prefix/assets/h5/unrelated.bin.gz"
+        self.store[other] = b"data"
+
+        s3lfs = self._s3lfs()
+        s3lfs._claim_inflight(base)
+        s3lfs.cleanup_s3(force=True)
+
+        self.assertIn(base, self.store, "claimed asset was collected")
+        self.assertNotIn(
+            other, self.store, "a claim on one path protected a different path"
+        )
+
+    def test_key_matching_rejects_lookalikes(self):
+        s3lfs = self._s3lfs()
+        base = "test-prefix/assets/h/a.bin.gz"
+
+        self.assertTrue(s3lfs._key_covered_by(base, {base}))
+        self.assertTrue(s3lfs._key_covered_by(f"{base}.chunk12", {base}))
+        # A longer path that merely starts with the same characters.
+        self.assertFalse(
+            s3lfs._key_covered_by("test-prefix/assets/h/a.bin.gz2", {base})
+        )
+        self.assertFalse(s3lfs._key_covered_by(f"{base}.chunkX", {base}))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #87, taking the path-aware-GC option rather than content-addressed storage. Stacked on #96.

## The mismatch

Objects live at `assets/{hash}/{manifest_key}.gz`, so the storage unit is **hash + path**. GC judged reachability on the **hash alone**. Those disagree, and it leaked in both directions:

- `a/x.bin` and `b/x.bin` share hash `h`; remove `a/x.bin`. `h` is still referenced by `b/x.bin`, so `assets/h/a/x.bin.gz` was **never collected**.
- Rename a file and `assets/h/oldpath.gz` stayed reachable-by-hash forever, though nothing could address it.

Reachability is now the set of base keys the manifest implies. A key is live if it is one of those, or a `.chunkN` belonging to one.

## Knock-on changes

**The in-flight registry moves from hashes to base keys.** Otherwise a claim on one path would protect a different path sharing its content — the same conflation, reintroduced through the registry added in #94.

**`remove_file` / `remove_subtree` now delete chunks.** They deleted only the base `.gz`, orphaning every chunk of a large file. Previously those orphans were also uncollectable when the hash stayed referenced elsewhere; now they would be collected eventually, but `--purge-from-s3` should mean *now*.

## What this deliberately does not do

Deduplication stays per-path: two identical files at different paths still occupy two objects. **The README's claim that identical files are stored only once remains inaccurate.** Fixing that means content-addressed storage (`assets/{hash}.gz`) and a migration, which is the option not taken here. Either the layout or the documentation should change; I'd suggest correcting the docs unless the storage saving matters.

## A regression an existing test caught

An earlier draft collected any key under the prefix that wasn't in the live set, including malformed ones. `test_cleanup_s3_short_key_paths` failed and was right to: s3lfs didn't put those there in a form it recognises, so they are not ours to delete. Keys must now have the shape of an asset before being considered — restoring the intent of the old `len(parts) < 3` guard.

## Verification

Five of the seven new tests fail on the parent commit. Three tests from #94 were updated for the key-based API.

`61 failed / 561 passed` → `61 failed / 568 passed`, failure set identical. The 61 are the missing-`python`-binary failures fixed in #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UrDtdFKGwQZp8oYGwL2rj