### PR TITLE
Let pre-push abort the push, and install hooks atomically

### DIFF
--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -777,20 +777,36 @@ S3LFS_HOOK_END = "# <<< s3lfs hook <<<"
 _POST_MERGE_BODY = """\
 # Auto-checkout s3lfs files after merge
 if command -v s3lfs >/dev/null 2>&1; then
-    s3lfs checkout --all 2>&1 || echo "s3lfs: warning: post-merge checkout failed"
+    if ! s3lfs checkout --all 2>&1; then
+        echo "s3lfs: ERROR: post-merge checkout failed" >&2
+        echo "s3lfs: large files may be missing or stale; run 's3lfs checkout --all'" >&2
+    fi
 fi"""
 
 _POST_CHECKOUT_BODY = """\
 # Auto-checkout s3lfs files after checkout
 # Only run on branch checkouts ($3 == 1), not file checkouts
 if [ "$3" = "1" ] && command -v s3lfs >/dev/null 2>&1; then
-    s3lfs checkout --all 2>&1 || echo "s3lfs: warning: post-checkout checkout failed"
+    if ! s3lfs checkout --all 2>&1; then
+        echo "s3lfs: ERROR: post-checkout checkout failed" >&2
+        echo "s3lfs: large files may be missing or stale; run 's3lfs checkout --all'" >&2
+    fi
 fi"""
 
 _PRE_PUSH_BODY = """\
-# Auto-track modified s3lfs files before push
+# Auto-track modified s3lfs files before push.
+#
+# This hook aborts the push on failure, and that is deliberate. It uploads
+# the content the manifest being pushed refers to; if the upload fails and
+# the push proceeds, collaborators fetch a manifest whose hashes have no
+# objects behind them and every checkout 404s. Failing here is recoverable,
+# pushing a broken manifest is not.
 if command -v s3lfs >/dev/null 2>&1; then
-    s3lfs track --modified 2>&1 || echo "s3lfs: warning: pre-push track failed"
+    if ! s3lfs track --modified 2>&1; then
+        echo "s3lfs: pre-push track failed; aborting push" >&2
+        echo "s3lfs: push anyway with --no-verify if you are sure" >&2
+        exit 1
+    fi
 fi"""
 
 HOOK_SCRIPTS = {
@@ -840,9 +856,28 @@ def _install_hook(hooks_dir, hook_name, hook_block):
     else:
         content = shebang + "\n" + hook_block + "\n"
 
-    hook_path.write_text(content)
-    hook_path.chmod(0o755)
+    _write_hook_atomically(hook_path, content)
     return hook_path
+
+
+def _write_hook_atomically(hook_path, content):
+    """Replace a hook file in one step.
+
+    write_text truncates before writing, so an interrupt part-way through
+    leaves a user's pre-existing hook truncated and executable. Write to a
+    sibling temp file and rename, which is atomic within a directory.
+    """
+    from uuid import uuid4
+
+    temp_path = hook_path.with_name(f"{hook_path.name}.{uuid4().hex}.tmp")
+    try:
+        temp_path.write_text(content)
+        temp_path.chmod(0o755)
+        temp_path.replace(hook_path)
+    except Exception:
+        if temp_path.exists():
+            temp_path.unlink()
+        raise
 
 
 def _uninstall_hook(hooks_dir, hook_name):
@@ -870,7 +905,7 @@ def _uninstall_hook(hooks_dir, hook_name):
     if stripped == "" or stripped == "#!/bin/sh":
         hook_path.unlink()
     else:
-        hook_path.write_text(new_content)
+        _write_hook_atomically(hook_path, new_content)
 
     return True
 

--- a/tests/test_hook_behaviour.py
+++ b/tests/test_hook_behaviour.py
@@ -1,0 +1,124 @@
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from s3lfs.cli import HOOK_SCRIPTS, _install_hook, _uninstall_hook
+
+
+class TestHookExitStatus(unittest.TestCase):
+    """pre-push must abort the push when tracking fails.
+
+    pre-push uploads the content the manifest being pushed refers to. If the
+    upload fails and the push proceeds, collaborators fetch a manifest whose
+    hashes have no objects behind them.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        self.hooks_dir = Path(self.temp_dir) / "hooks"
+        self.hooks_dir.mkdir()
+        self.bin_dir = Path(self.temp_dir) / "bin"
+        self.bin_dir.mkdir()
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _fake_s3lfs(self, exit_code):
+        """A stand-in s3lfs on PATH that exits with the given status."""
+        script = self.bin_dir / "s3lfs"
+        script.write_text(f"#!/bin/sh\necho 'fake s3lfs ran'\nexit {exit_code}\n")
+        script.chmod(0o755)
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin_dir}:{env['PATH']}"
+        return env
+
+    def _run_hook(self, hook_name, exit_code, args=()):
+        env = self._fake_s3lfs(exit_code)
+        hook_path = _install_hook(self.hooks_dir, hook_name, HOOK_SCRIPTS[hook_name])
+        return subprocess.run(
+            ["/bin/sh", str(hook_path), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_pre_push_fails_when_track_fails(self):
+        result = self._run_hook("pre-push", exit_code=1)
+        self.assertNotEqual(
+            result.returncode, 0, "pre-push masked a failed track and allowed the push"
+        )
+        self.assertIn("aborting push", result.stderr)
+
+    def test_pre_push_succeeds_when_track_succeeds(self):
+        result = self._run_hook("pre-push", exit_code=0)
+        self.assertEqual(result.returncode, 0)
+
+    def test_post_merge_does_not_fail_the_merge(self):
+        """The merge has already happened; failing here helps nobody."""
+        result = self._run_hook("post-merge", exit_code=1)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("ERROR", result.stderr)
+
+    def test_post_checkout_reports_failure_on_stderr(self):
+        # $3 == 1 marks a branch checkout
+        result = self._run_hook("post-checkout", exit_code=1, args=("a", "b", "1"))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("ERROR", result.stderr)
+
+
+class TestHookInstallAtomicity(unittest.TestCase):
+    """Installing a hook must not damage a pre-existing one."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.hooks_dir = Path(self.temp_dir) / "hooks"
+        self.hooks_dir.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_preserves_existing_hook_content(self):
+        hook_path = self.hooks_dir / "pre-push"
+        hook_path.write_text("#!/bin/sh\necho 'user hook'\n")
+        hook_path.chmod(0o755)
+
+        _install_hook(self.hooks_dir, "pre-push", HOOK_SCRIPTS["pre-push"])
+
+        content = hook_path.read_text()
+        self.assertIn("user hook", content)
+        self.assertIn("s3lfs", content)
+
+    def test_installed_hook_is_executable(self):
+        _install_hook(self.hooks_dir, "pre-push", HOOK_SCRIPTS["pre-push"])
+        mode = (self.hooks_dir / "pre-push").stat().st_mode
+        self.assertTrue(mode & stat.S_IXUSR)
+
+    def test_uninstall_restores_user_content(self):
+        hook_path = self.hooks_dir / "pre-push"
+        hook_path.write_text("#!/bin/sh\necho 'user hook'\n")
+        hook_path.chmod(0o755)
+
+        _install_hook(self.hooks_dir, "pre-push", HOOK_SCRIPTS["pre-push"])
+        _uninstall_hook(self.hooks_dir, "pre-push")
+
+        content = hook_path.read_text()
+        self.assertIn("user hook", content)
+        self.assertNotIn("s3lfs", content)
+
+    def test_no_temp_files_left_behind(self):
+        _install_hook(self.hooks_dir, "pre-push", HOOK_SCRIPTS["pre-push"])
+        leftovers = [
+            p.name for p in self.hooks_dir.iterdir() if p.name.endswith(".tmp")
+        ]
+        self.assertEqual(leftovers, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_hooks.py
+++ b/tests/test_install_hooks.py
@@ -261,15 +261,34 @@ class TestInstallCommand(unittest.TestCase):
         content = hook_path.read_text()
         self.assertIn('"$3" = "1"', content)
 
-    def test_hooks_warn_on_failure(self):
-        """Hook scripts use || echo to warn rather than fail the git operation."""
+    def test_post_hooks_warn_rather_than_fail(self):
+        """post-* hooks run after git has already committed its state.
+
+        Failing them helps nobody, so they report loudly and exit zero.
+        """
         runner = CliRunner()
         runner.invoke(cli, ["install"])
 
-        for hook_name in ["post-merge", "post-checkout", "pre-push"]:
+        for hook_name in ["post-merge", "post-checkout"]:
             hook_path = Path(self.temp_dir) / ".git" / "hooks" / hook_name
             content = hook_path.read_text()
-            self.assertIn("|| echo", content, f"{hook_name} should warn on failure")
+            self.assertIn("ERROR", content, f"{hook_name} should report failure")
+            self.assertNotIn(
+                "exit 1", content, f"{hook_name} should not fail the git operation"
+            )
+
+    def test_pre_push_aborts_on_failure(self):
+        """pre-push is the last point at which a bad push can be stopped.
+
+        It uploads the content the manifest being pushed refers to; letting
+        the push proceed after a failed upload publishes a manifest whose
+        hashes have no objects behind them.
+        """
+        runner = CliRunner()
+        runner.invoke(cli, ["install"])
+
+        content = (Path(self.temp_dir) / ".git" / "hooks" / "pre-push").read_text()
+        self.assertIn("exit 1", content)
 
     def test_hooks_check_s3lfs_exists(self):
         """Hook scripts check that s3lfs command exists before running."""


### PR DESCRIPTION
Fixes #88. Stacked on #97.

## The behaviour change you may want to argue with

All three hooks ended in `|| echo`, which forces exit status zero.

For **post-merge / post-checkout** that is defensible — git has already committed its ref and index updates, so failing helps nobody. They now report loudly on stderr and still exit zero.

For **pre-push** it is not. That hook uploads the content the manifest being pushed refers to, and it is the last point at which a bad push can be stopped. Masking a failed upload publishes a manifest whose hashes have no objects behind them, and every collaborator's checkout 404s. It now aborts, pointing at `--no-verify`.

**This contradicts an existing test.** `test_hooks_warn_on_failure` asserted `|| echo` for all three hooks, encoding the current behaviour as intended. I've updated it, but that makes this a deliberate reversal rather than a bug fix, and it's the thing to look at first if you disagree.

The concrete risk: a push is now blocked when `s3lfs track --modified` fails for an unrelated reason — absent credentials, say — on a branch that touches no large files. The hook already guards on `command -v s3lfs`, so it only runs where s3lfs is installed, and `--no-verify` is the escape hatch. I think correctness wins here, but it is a judgement call about your users rather than a fact about the code.

## Atomic hook writes

Install and uninstall both used `write_text`, which truncates before writing. An interrupt part-way through leaves a user's pre-existing hook truncated *and executable* — a corrupted hook that still runs. Both now write to a sibling temp file and rename.

## Verification

Three of the eight new tests fail on the parent commit. The hook tests execute the generated scripts against a stub `s3lfs` on `PATH` that exits with a chosen status, so they check real shell behaviour rather than asserting on the script text.

`61 failed / 568 passed` → `61 failed / 577 passed`, failure set identical.

## Not addressed

`pre-push` still mutates the working tree's `.s3_manifest.yaml` at push time, *after* the commit being pushed was created. That manifest change is unstaged and never travels with the push, so the pushed commit's manifest and the local manifest diverge. Fixing it properly means moving tracking to `pre-commit` so the manifest and the commit agree, which is a larger design change than this PR should carry. #88 stays open for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UrDtdFKGwQZp8oYGwL2rj