### PR TITLE
Retry chunked transfers, add jitter, stop retrying hopeless errors

### DIFF
--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -777,20 +777,36 @@ S3LFS_HOOK_END = "# <<< s3lfs hook <<<"
 _POST_MERGE_BODY = """\
 # Auto-checkout s3lfs files after merge
 if command -v s3lfs >/dev/null 2>&1; then
-    s3lfs checkout --all 2>&1 || echo "s3lfs: warning: post-merge checkout failed"
+    if ! s3lfs checkout --all 2>&1; then
+        echo "s3lfs: ERROR: post-merge checkout failed" >&2
+        echo "s3lfs: large files may be missing or stale; run 's3lfs checkout --all'" >&2
+    fi
 fi"""
 
 _POST_CHECKOUT_BODY = """\
 # Auto-checkout s3lfs files after checkout
 # Only run on branch checkouts ($3 == 1), not file checkouts
 if [ "$3" = "1" ] && command -v s3lfs >/dev/null 2>&1; then
-    s3lfs checkout --all 2>&1 || echo "s3lfs: warning: post-checkout checkout failed"
+    if ! s3lfs checkout --all 2>&1; then
+        echo "s3lfs: ERROR: post-checkout checkout failed" >&2
+        echo "s3lfs: large files may be missing or stale; run 's3lfs checkout --all'" >&2
+    fi
 fi"""
 
 _PRE_PUSH_BODY = """\
-# Auto-track modified s3lfs files before push
+# Auto-track modified s3lfs files before push.
+#
+# This hook aborts the push on failure, and that is deliberate. It uploads
+# the content the manifest being pushed refers to; if the upload fails and
+# the push proceeds, collaborators fetch a manifest whose hashes have no
+# objects behind them and every checkout 404s. Failing here is recoverable,
+# pushing a broken manifest is not.
 if command -v s3lfs >/dev/null 2>&1; then
-    s3lfs track --modified 2>&1 || echo "s3lfs: warning: pre-push track failed"
+    if ! s3lfs track --modified 2>&1; then
+        echo "s3lfs: pre-push track failed; aborting push" >&2
+        echo "s3lfs: push anyway with --no-verify if you are sure" >&2
+        exit 1
+    fi
 fi"""
 
 HOOK_SCRIPTS = {
@@ -840,9 +856,28 @@ def _install_hook(hooks_dir, hook_name, hook_block):
     else:
         content = shebang + "\n" + hook_block + "\n"
 
-    hook_path.write_text(content)
-    hook_path.chmod(0o755)
+    _write_hook_atomically(hook_path, content)
     return hook_path
+
+
+def _write_hook_atomically(hook_path, content):
+    """Replace a hook file in one step.
+
+    write_text truncates before writing, so an interrupt part-way through
+    leaves a user's pre-existing hook truncated and executable. Write to a
+    sibling temp file and rename, which is atomic within a directory.
+    """
+    from uuid import uuid4
+
+    temp_path = hook_path.with_name(f"{hook_path.name}.{uuid4().hex}.tmp")
+    try:
+        temp_path.write_text(content)
+        temp_path.chmod(0o755)
+        temp_path.replace(hook_path)
+    except Exception:
+        if temp_path.exists():
+            temp_path.unlink()
+        raise
 
 
 def _uninstall_hook(hooks_dir, hook_name):
@@ -870,7 +905,7 @@ def _uninstall_hook(hooks_dir, hook_name):
     if stripped == "" or stripped == "#!/bin/sh":
         hook_path.unlink()
     else:
-        hook_path.write_text(new_content)
+        _write_hook_atomically(hook_path, new_content)
 
     return True
 

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -1,11 +1,13 @@
 import contextlib
 import fnmatch
+import functools
 import glob
 import gzip
 import hashlib
 import json
 import mmap
 import os
+import random
 import re
 import shutil
 import signal
@@ -69,8 +71,43 @@ ERROR_MESSAGES = {
 }
 
 
+# Errors that will not succeed on a second attempt. Retrying them wastes the
+# caller's time and buries the real cause behind a delay.
+NON_RETRYABLE_S3_CODES = frozenset(
+    {
+        "AccessDenied",
+        "AllAccessDisabled",
+        "InvalidAccessKeyId",
+        "SignatureDoesNotMatch",
+        "NoSuchBucket",
+        "InvalidBucketName",
+        "AccountProblem",
+        "InvalidObjectState",
+        "EntityTooLarge",
+    }
+)
+
+
+def _is_retryable(exc):
+    """Is this exception worth another attempt?"""
+    if isinstance(exc, ClientError):
+        code = exc.response.get("Error", {}).get("Code", "")
+        if code in NON_RETRYABLE_S3_CODES:
+            return False
+        # 4xx other than throttling and request timeout are client errors.
+        status = exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+        if isinstance(status, int) and 400 <= status < 500:
+            return code in {
+                "RequestTimeout",
+                "SlowDown",
+                "Throttling",
+                "ThrottlingException",
+            }
+    return True
+
+
 def retry(times, exceptions, max_delay=30):
-    """Retry decorator with exponential backoff.
+    """Retry decorator with exponential backoff and full jitter.
 
     :param times: Maximum number of retry attempts.
     :param exceptions: Tuple of exception types that trigger a retry.
@@ -78,20 +115,25 @@ def retry(times, exceptions, max_delay=30):
     """
 
     def decorator(func):
+        @functools.wraps(func)
         def newfn(*args, **kwargs):
             for attempt in range(times):
                 try:
                     return func(*args, **kwargs)
                 except exceptions as exc:
-                    if attempt < times - 1:
-                        delay = min(2 ** (attempt + 1), max_delay)
-                        print(
-                            f"Retry {attempt + 1}/{times} for {func.__name__} "
-                            f"in {delay}s: {exc}"
-                        )
-                        time.sleep(delay)
-                    else:
+                    if attempt >= times - 1 or not _is_retryable(exc):
                         raise
+                    # Full jitter. Without it, every worker that failed at the
+                    # same moment retries at the same moment, so a transient
+                    # blip becomes a synchronised stampede against the
+                    # endpoint that just failed.
+                    ceiling = min(2 ** (attempt + 1), max_delay)
+                    delay = random.uniform(0, ceiling)
+                    print(
+                        f"Retry {attempt + 1}/{times} for {func.__name__} "
+                        f"in {delay:.1f}s: {exc}"
+                    )
+                    time.sleep(delay)
 
         return newfn
 
@@ -1635,22 +1677,32 @@ class S3LFS:
 
         return (manifest_key, file_hash, chunks)
 
+    @retry(3, (BotoCoreError, ClientError, SSLError))
+    def _put_chunk(self, path, s3_key, extra_args):
+        """PUT one chunk. Retried, so it must not consume its input."""
+        with open(path, "rb") as f:
+            self._get_s3_client().upload_fileobj(
+                f,
+                self.bucket_name,
+                s3_key,
+                ExtraArgs=extra_args,
+                Config=self.config,
+            )
+        return path.stat().st_size
+
     def _upload_chunk(self, chunk_info):
-        """Upload a single compressed chunk to S3."""
+        """Upload a single compressed chunk to S3.
+
+        The chunk file is removed once, after all retry attempts. Deleting it
+        inside the retried call would leave nothing for the next attempt to
+        read, so the retry could only ever fail.
+        """
         path = chunk_info["path"]
         s3_key = chunk_info["s3_key"]
         extra_args = chunk_info["extra_args"]
 
         try:
-            with open(path, "rb") as f:
-                self._get_s3_client().upload_fileobj(
-                    f,
-                    self.bucket_name,
-                    s3_key,
-                    ExtraArgs=extra_args,
-                    Config=self.config,
-                )
-            bytes_uploaded = path.stat().st_size
+            bytes_uploaded = self._put_chunk(path, s3_key, extra_args)
         finally:
             try:
                 os.remove(path)
@@ -1817,6 +1869,7 @@ class S3LFS:
 
         self.parallel_download_chunked(files_to_download, silence=silence)
 
+    @retry(3, (BotoCoreError, ClientError, SSLError))
     def _discover_chunks_for_file(self, manifest_key, file_hash):
         """Discover S3 chunks for a single file."""
         s3_key = f"{self.repo_prefix}/assets/{file_hash}/{manifest_key}.gz"
@@ -1850,6 +1903,7 @@ class S3LFS:
                 }
             ]
 
+    @retry(3, (BotoCoreError, ClientError, SSLError))
     def _download_chunk(self, chunk_info, target_path):
         """Download a single S3 chunk to a target path."""
         with open(target_path, "wb") as f:

--- a/tests/test_hook_behaviour.py
+++ b/tests/test_hook_behaviour.py
@@ -1,0 +1,124 @@
+import os
+import shutil
+import stat
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from s3lfs.cli import HOOK_SCRIPTS, _install_hook, _uninstall_hook
+
+
+class TestHookExitStatus(unittest.TestCase):
+    """pre-push must abort the push when tracking fails.
+
+    pre-push uploads the content the manifest being pushed refers to. If the
+    upload fails and the push proceeds, collaborators fetch a manifest whose
+    hashes have no objects behind them.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        self.hooks_dir = Path(self.temp_dir) / "hooks"
+        self.hooks_dir.mkdir()
+        self.bin_dir = Path(self.temp_dir) / "bin"
+        self.bin_dir.mkdir()
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _fake_s3lfs(self, exit_code):
+        """A stand-in s3lfs on PATH that exits with the given status."""
+        script = self.bin_dir / "s3lfs"
+        script.write_text(f"#!/bin/sh\necho 'fake s3lfs ran'\nexit {exit_code}\n")
+        script.chmod(0o755)
+        env = dict(os.environ)
+        env["PATH"] = f"{self.bin_dir}:{env['PATH']}"
+        return env
+
+    def _run_hook(self, hook_name, exit_code, args=()):
+        env = self._fake_s3lfs(exit_code)
+        hook_path = _install_hook(self.hooks_dir, hook_name, HOOK_SCRIPTS[hook_name])
+        return subprocess.run(
+            ["/bin/sh", str(hook_path), *args],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+
+    def test_pre_push_fails_when_track_fails(self):
+        result = self._run_hook("pre-push", exit_code=1)
+        self.assertNotEqual(
+            result.returncode, 0, "pre-push masked a failed track and allowed the push"
+        )
+        self.assertIn("aborting push", result.stderr)
+
+    def test_pre_push_succeeds_when_track_succeeds(self):
+        result = self._run_hook("pre-push", exit_code=0)
+        self.assertEqual(result.returncode, 0)
+
+    def test_post_merge_does_not_fail_the_merge(self):
+        """The merge has already happened; failing here helps nobody."""
+        result = self._run_hook("post-merge", exit_code=1)
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("ERROR", result.stderr)
+
+    def test_post_checkout_reports_failure_on_stderr(self):
+        # $3 == 1 marks a branch checkout
+        result = self._run_hook("post-checkout", exit_code=1, args=("a", "b", "1"))
+        self.assertEqual(result.returncode, 0)
+        self.assertIn("ERROR", result.stderr)
+
+
+class TestHookInstallAtomicity(unittest.TestCase):
+    """Installing a hook must not damage a pre-existing one."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.hooks_dir = Path(self.temp_dir) / "hooks"
+        self.hooks_dir.mkdir()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_preserves_existing_hook_content(self):
+        hook_path = self.hooks_dir / "pre-push"
+        hook_path.write_text("#!/bin/sh\necho 'user hook'\n")
+        hook_path.chmod(0o755)
+
+        _install_hook(self.hooks_dir, "pre-push", HOOK_SCRIPTS["pre-push"])
+
+        content = hook_path.read_text()
+        self.assertIn("user hook", content)
+        self.assertIn("s3lfs", content)
+
+    def test_installed_hook_is_executable(self):
+        _install_hook(self.hooks_dir, "pre-push", HOOK_SCRIPTS["pre-push"])
+        mode = (self.hooks_dir / "pre-push").stat().st_mode
+        self.assertTrue(mode & stat.S_IXUSR)
+
+    def test_uninstall_restores_user_content(self):
+        hook_path = self.hooks_dir / "pre-push"
+        hook_path.write_text("#!/bin/sh\necho 'user hook'\n")
+        hook_path.chmod(0o755)
+
+        _install_hook(self.hooks_dir, "pre-push", HOOK_SCRIPTS["pre-push"])
+        _uninstall_hook(self.hooks_dir, "pre-push")
+
+        content = hook_path.read_text()
+        self.assertIn("user hook", content)
+        self.assertNotIn("s3lfs", content)
+
+    def test_no_temp_files_left_behind(self):
+        _install_hook(self.hooks_dir, "pre-push", HOOK_SCRIPTS["pre-push"])
+        leftovers = [
+            p.name for p in self.hooks_dir.iterdir() if p.name.endswith(".tmp")
+        ]
+        self.assertEqual(leftovers, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_install_hooks.py
+++ b/tests/test_install_hooks.py
@@ -261,15 +261,34 @@ class TestInstallCommand(unittest.TestCase):
         content = hook_path.read_text()
         self.assertIn('"$3" = "1"', content)
 
-    def test_hooks_warn_on_failure(self):
-        """Hook scripts use || echo to warn rather than fail the git operation."""
+    def test_post_hooks_warn_rather_than_fail(self):
+        """post-* hooks run after git has already committed its state.
+
+        Failing them helps nobody, so they report loudly and exit zero.
+        """
         runner = CliRunner()
         runner.invoke(cli, ["install"])
 
-        for hook_name in ["post-merge", "post-checkout", "pre-push"]:
+        for hook_name in ["post-merge", "post-checkout"]:
             hook_path = Path(self.temp_dir) / ".git" / "hooks" / hook_name
             content = hook_path.read_text()
-            self.assertIn("|| echo", content, f"{hook_name} should warn on failure")
+            self.assertIn("ERROR", content, f"{hook_name} should report failure")
+            self.assertNotIn(
+                "exit 1", content, f"{hook_name} should not fail the git operation"
+            )
+
+    def test_pre_push_aborts_on_failure(self):
+        """pre-push is the last point at which a bad push can be stopped.
+
+        It uploads the content the manifest being pushed refers to; letting
+        the push proceed after a failed upload publishes a manifest whose
+        hashes have no objects behind them.
+        """
+        runner = CliRunner()
+        runner.invoke(cli, ["install"])
+
+        content = (Path(self.temp_dir) / ".git" / "hooks" / "pre-push").read_text()
+        self.assertIn("exit 1", content)
 
     def test_hooks_check_s3lfs_exists(self):
         """Hook scripts check that s3lfs command exists before running."""

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -68,9 +68,13 @@ class TestRetryDecorator(unittest.TestCase):
 
         # 3 sleeps for 4 attempts (no sleep after final failure)
         self.assertEqual(len(sleep_calls), 3)
-        self.assertEqual(sleep_calls[0], 2)  # 2^1
-        self.assertEqual(sleep_calls[1], 4)  # 2^2
-        self.assertEqual(sleep_calls[2], 8)  # 2^3
+        # Full jitter: each delay is drawn from [0, 2**(attempt+1)] rather
+        # than being exactly that ceiling. A fixed schedule makes every
+        # worker that failed together retry together.
+        self.assertGreaterEqual(sleep_calls[0], 0)
+        self.assertLessEqual(sleep_calls[0], 2)  # 2^1
+        self.assertLessEqual(sleep_calls[1], 4)  # 2^2
+        self.assertLessEqual(sleep_calls[2], 8)  # 2^3
 
     def test_max_delay_cap(self):
         sleep_calls = []

--- a/tests/test_retry_behaviour.py
+++ b/tests/test_retry_behaviour.py
@@ -1,0 +1,213 @@
+import os
+import shutil
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import yaml
+from botocore.exceptions import ClientError
+
+from s3lfs.core import S3LFS, _is_retryable, retry
+
+
+def _client_error(code, status=400):
+    response: dict = {
+        "Error": {"Code": code, "Message": code},
+        "ResponseMetadata": {"HTTPStatusCode": status},
+    }
+    return ClientError(response, "PutObject")  # type: ignore[arg-type]
+
+
+class TestRetryClassification(unittest.TestCase):
+    """Retrying an error that cannot succeed only delays the real message."""
+
+    def test_permission_errors_are_not_retryable(self):
+        for code in ("AccessDenied", "InvalidAccessKeyId", "SignatureDoesNotMatch"):
+            self.assertFalse(_is_retryable(_client_error(code, 403)), code)
+
+    def test_missing_bucket_is_not_retryable(self):
+        self.assertFalse(_is_retryable(_client_error("NoSuchBucket", 404)))
+
+    def test_throttling_is_retryable(self):
+        self.assertTrue(_is_retryable(_client_error("SlowDown", 503)))
+        self.assertTrue(_is_retryable(_client_error("RequestTimeout", 400)))
+
+    def test_server_errors_are_retryable(self):
+        self.assertTrue(_is_retryable(_client_error("InternalError", 500)))
+
+    def test_non_client_errors_are_retryable(self):
+        self.assertTrue(_is_retryable(OSError("connection reset")))
+
+
+class TestRetryMechanics(unittest.TestCase):
+    def test_gives_up_immediately_on_non_retryable(self):
+        calls = []
+
+        @retry(3, (ClientError,))
+        def always_denied():
+            calls.append(1)
+            raise _client_error("AccessDenied", 403)
+
+        with self.assertRaises(ClientError):
+            always_denied()
+
+        self.assertEqual(len(calls), 1, "a non-retryable error was retried")
+
+    def test_retries_then_succeeds(self):
+        calls = []
+
+        @retry(3, (ClientError,))
+        def flaky():
+            calls.append(1)
+            if len(calls) < 3:
+                raise _client_error("InternalError", 500)
+            return "ok"
+
+        with patch("time.sleep"):
+            self.assertEqual(flaky(), "ok")
+        self.assertEqual(len(calls), 3)
+
+    def test_backoff_is_jittered(self):
+        """Fixed backoff makes every worker retry in lockstep."""
+        delays: list = []
+
+        @retry(4, (ClientError,))
+        def always_fails():
+            raise _client_error("InternalError", 500)
+
+        with patch("time.sleep", side_effect=delays.append):
+            with self.assertRaises(ClientError):
+                always_fails()
+
+        self.assertEqual(len(delays), 3)
+        # Full jitter: each delay lies in [0, 2**(attempt+1)].
+        for attempt, delay in enumerate(delays):
+            self.assertGreaterEqual(delay, 0)
+            self.assertLessEqual(delay, 2 ** (attempt + 1))
+        # Not the old fixed schedule.
+        self.assertNotEqual(delays, [2, 4, 8])
+
+    def test_preserves_function_metadata(self):
+        @retry(2, (ClientError,))
+        def named_function():
+            return 1
+
+        self.assertEqual(named_function.__name__, "named_function")
+
+
+class TestChunkTransferRetries(unittest.TestCase):
+    """The chunked pipeline handles the largest files and had no retry."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+        os.makedirs(".git")
+        with open(".s3_manifest.yaml", "w") as f:
+            yaml.safe_dump(
+                {
+                    "bucket_name": "test-bucket",
+                    "repo_prefix": "test-prefix",
+                    "files": {},
+                },
+                f,
+            )
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _s3lfs(self, client):
+        with patch("boto3.client"):
+            return S3LFS(
+                bucket_name="test-bucket",
+                s3_factory=lambda no_sign: client,
+            )
+
+    def test_upload_chunk_survives_a_transient_failure(self):
+        """The retry must still find its input file.
+
+        The chunk was previously deleted in a finally that ran on the first
+        failure, so any retry could only fail with FileNotFoundError.
+        """
+        attempts: list = []
+        uploaded: dict = {}
+
+        client = MagicMock()
+
+        def upload_fileobj(fileobj, bucket, key, **kwargs):
+            attempts.append(key)
+            if len(attempts) == 1:
+                raise _client_error("InternalError", 500)
+            uploaded[key] = fileobj.read()
+
+        client.upload_fileobj.side_effect = upload_fileobj
+        s3lfs = self._s3lfs(client)
+
+        chunk_path = Path("chunk0.gz")
+        chunk_path.write_bytes(b"chunk payload")
+        chunk_info = {
+            "path": chunk_path,
+            "s3_key": "test-prefix/assets/h/f.gz.chunk0",
+            "chunk_index": 0,
+            "extra_args": {},
+        }
+
+        with patch("time.sleep"):
+            key, size = s3lfs._upload_chunk(chunk_info)
+
+        self.assertEqual(len(attempts), 2, "the chunk upload was not retried")
+        self.assertEqual(uploaded[key], b"chunk payload")
+        self.assertFalse(chunk_path.exists(), "chunk file should be cleaned up once")
+
+    def test_upload_chunk_cleans_up_after_permanent_failure(self):
+        client = MagicMock()
+        client.upload_fileobj.side_effect = _client_error("AccessDenied", 403)
+        s3lfs = self._s3lfs(client)
+
+        chunk_path = Path("chunk0.gz")
+        chunk_path.write_bytes(b"chunk payload")
+        chunk_info = {
+            "path": chunk_path,
+            "s3_key": "test-prefix/assets/h/f.gz.chunk0",
+            "chunk_index": 0,
+            "extra_args": {},
+        }
+
+        with self.assertRaises(ClientError):
+            s3lfs._upload_chunk(chunk_info)
+
+        self.assertFalse(chunk_path.exists(), "chunk file leaked after failure")
+
+    def test_download_chunk_survives_a_transient_failure(self):
+        attempts: list = []
+        client = MagicMock()
+
+        def download_fileobj(Bucket=None, Key=None, Fileobj=None, **kwargs):
+            attempts.append(Key)
+            if len(attempts) == 1:
+                raise _client_error("InternalError", 500)
+            Fileobj.write(b"downloaded")
+
+        client.download_fileobj.side_effect = download_fileobj
+        s3lfs = self._s3lfs(client)
+
+        target = Path("out.gz")
+        chunk_info = {
+            "manifest_key": "f.bin",
+            "s3_key": "test-prefix/assets/h/f.gz",
+            "chunk_index": 0,
+            "is_chunked": False,
+            "num_chunks": 1,
+        }
+
+        with patch("time.sleep"):
+            s3lfs._download_chunk(chunk_info, target)
+
+        self.assertEqual(len(attempts), 2, "the chunk download was not retried")
+        self.assertEqual(target.read_bytes(), b"downloaded")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #89. Stacked on #98.

## The chunked pipeline had no retry at all

`@retry` was applied at exactly two call sites. The chunked pipeline — which handles the **largest** files, where transient failures are most likely — had none, so a single blip aborted the whole file.

`_upload_chunk`, `_download_chunk`, and `_discover_chunks_for_file` are now retried.

### `_upload_chunk` needed restructuring first

Simply decorating it would not have worked. It removed its chunk file in a `finally` that runs on the **first** failure, so the retry would find nothing to read and fail with `FileNotFoundError` — which isn't in the retried exception set. The decorator would have looked correct and done nothing.

The PUT is now a separate retried call, with cleanup once after all attempts. `_download_chunk` reopens its target with `"wb"` each attempt and discovery is a list call, so both were already idempotent.

## Jitter

A fixed 2/4/8 schedule means every worker that failed at the same moment retries at the same moment — a transient blip becomes a synchronised stampede against the endpoint that just failed. Now full jitter: each delay is drawn from `[0, 2**(attempt+1)]`.

## Hopeless errors are no longer retried

Permission failures, missing buckets, and 4xx responses other than throttling and request timeout now fail immediately. A 403 previously took three attempts and two sleeps before surfacing the real cause.

## Measured

A chunk upload whose first PUT returns a 500:

| | Attempts | Result |
| --- | --- | --- |
| Before | 1 | `ClientError: InternalError` |
| After | 2 | uploaded |

`61 failed / 577 passed` → `61 failed / 589 passed`, failure set identical.

## A test I changed deliberately

`test_exponential_backoff_delays` asserted the exact delays `2, 4, 8`. It now asserts each delay lies within `[0, ceiling]`. That test encoded the fixed schedule as intended behaviour, so this is a deliberate reversal — flagging it rather than burying it.

## Not addressed

Still open in #89, and the issue stays open for them:

- No `abort_multipart_upload` anywhere. A killed process leaks incomplete multipart uploads that are billed and invisible to `cleanup_s3`, which lists only completed objects. A bucket lifecycle rule is the usual mitigation and deserves documenting.
- The skip-if-exists path compares a local MD5 against the S3 ETag, which can never match for multipart objects, so large files re-upload every time.
- A retry still re-compresses and re-splits the whole file at the `upload` level, since that path deletes its inputs in a `finally`. Only the chunk-level retry avoids redoing work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UrDtdFKGwQZp8oYGwL2rj