### PR TITLE
Use sys.executable instead of "python" in subprocess tests

### DIFF
--- a/tests/test_git_root_coverage.py
+++ b/tests/test_git_root_coverage.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -46,7 +47,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from outside git repo
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=outside_dir,
@@ -81,7 +82,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from different level directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=different_level_dir,
@@ -114,7 +115,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from parent directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=parent_dir,
@@ -148,7 +149,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from sibling directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=sibling_dir,
@@ -182,7 +183,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from nested directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=nested_dir,
@@ -219,7 +220,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from symlink directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=symlink_dir,
@@ -253,7 +254,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from absolute path directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=outside_dir,
@@ -293,7 +294,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
                 # Test ls command from different drive directory
                 result = subprocess.run(
-                    ["python", "-m", "s3lfs.cli", "ls"],
+                    [sys.executable, "-m", "s3lfs.cli", "ls"],
                     capture_output=True,
                     text=True,
                     cwd=different_drive_dir,
@@ -310,7 +311,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
             # Test ls command from different drive directory
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "ls"],
+                [sys.executable, "-m", "s3lfs.cli", "ls"],
                 capture_output=True,
                 text=True,
                 cwd=different_drive_dir,
@@ -346,7 +347,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from outside directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=outside_dir,

--- a/tests/test_ls_command_coverage.py
+++ b/tests/test_ls_command_coverage.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -30,7 +31,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command when not in git repo
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=non_git_dir,
@@ -51,7 +52,7 @@ class TestLSCommandCoverage(unittest.TestCase):
         # Don't create manifest file - it shouldn't exist
         # Test ls command when manifest doesn't exist
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -87,7 +88,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command from outside git repo
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=outside_dir,
@@ -117,7 +118,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with --all flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--all"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--all"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -146,7 +147,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with specific path
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -175,7 +176,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with --verbose flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--verbose"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--verbose"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -204,7 +205,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with --no-sign-request flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--no-sign-request"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--no-sign-request"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -234,7 +235,7 @@ class TestLSCommandCoverage(unittest.TestCase):
         # Test ls command with multiple flags
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "s3lfs.cli",
                 "ls",
@@ -270,7 +271,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with both path and --all flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "test_file.txt", "--all"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "test_file.txt", "--all"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -304,7 +305,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command from subdirectory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=subdir,
@@ -338,7 +339,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with specific path from subdirectory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=subdir,
@@ -367,7 +368,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with empty manifest
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -396,7 +397,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with nonexistent path
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "nonexistent_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "nonexistent_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,

--- a/tests/test_manifest_not_exists_coverage.py
+++ b/tests/test_manifest_not_exists_coverage.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -31,7 +32,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test track command without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "track", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "track", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -53,7 +54,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test track command with --modified flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "track", "--modified"],
+            [sys.executable, "-m", "s3lfs.cli", "track", "--modified"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -75,7 +76,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test track command with --verbose flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "track", "--verbose", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "track", "--verbose", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -98,7 +99,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         # Test track command with --no-sign-request flag without manifest file
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "s3lfs.cli",
                 "track",
@@ -126,7 +127,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test checkout command without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "checkout", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "checkout", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -148,7 +149,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test checkout command with --all flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "checkout", "--all"],
+            [sys.executable, "-m", "s3lfs.cli", "checkout", "--all"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -170,7 +171,14 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test checkout command with --verbose flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "checkout", "--verbose", "test_file.txt"],
+            [
+                sys.executable,
+                "-m",
+                "s3lfs.cli",
+                "checkout",
+                "--verbose",
+                "test_file.txt",
+            ],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -193,7 +201,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         # Test checkout command with --no-sign-request flag without manifest file
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "s3lfs.cli",
                 "checkout",
@@ -221,7 +229,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -243,7 +251,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --all flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--all"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--all"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -265,7 +273,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --verbose flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--verbose"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--verbose"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -287,7 +295,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --no-sign-request flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--no-sign-request"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--no-sign-request"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -309,7 +317,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test remove command without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "remove", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "remove", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -331,7 +339,14 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test remove command with --purge-from-s3 flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "remove", "--purge-from-s3", "test_file.txt"],
+            [
+                sys.executable,
+                "-m",
+                "s3lfs.cli",
+                "remove",
+                "--purge-from-s3",
+                "test_file.txt",
+            ],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -353,7 +368,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test cleanup command without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "cleanup"],
+            [sys.executable, "-m", "s3lfs.cli", "cleanup"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -375,7 +390,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test cleanup command with --force flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "cleanup", "--force"],
+            [sys.executable, "-m", "s3lfs.cli", "cleanup", "--force"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -397,7 +412,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test init command
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "init", "testbucket", "testprefix"],
+            [sys.executable, "-m", "s3lfs.cli", "init", "testbucket", "testprefix"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -417,7 +432,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         # Test init command with --no-sign-request flag
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "s3lfs.cli",
                 "init",
@@ -447,7 +462,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test init command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "init", "testbucket", "testprefix"],
+                [sys.executable, "-m", "s3lfs.cli", "init", "testbucket", "testprefix"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -472,7 +487,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
             # Test init command with --no-sign-request flag when not in git repo
             result = subprocess.run(
                 [
-                    "python",
+                    sys.executable,
                     "-m",
                     "s3lfs.cli",
                     "init",
@@ -509,7 +524,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test track command with no path and no --modified flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "track"],
+            [sys.executable, "-m", "s3lfs.cli", "track"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -541,7 +556,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test checkout command with no path and no --all flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "checkout"],
+            [sys.executable, "-m", "s3lfs.cli", "checkout"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -573,7 +588,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --all flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--all"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--all"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -602,7 +617,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --all flag and --verbose
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--all", "--verbose"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--all", "--verbose"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -631,7 +646,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --all flag and --no-sign-request
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--all", "--no-sign-request"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--all", "--no-sign-request"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -660,7 +675,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test remove command with directory pattern
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "remove", "test_dir/"],
+            [sys.executable, "-m", "s3lfs.cli", "remove", "test_dir/"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -689,7 +704,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test remove command with glob pattern
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "remove", "*.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "remove", "*.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -718,7 +733,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test cleanup command with --force flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "cleanup", "--force"],
+            [sys.executable, "-m", "s3lfs.cli", "cleanup", "--force"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -749,7 +764,14 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test cleanup command with --force flag and --no-sign-request
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "cleanup", "--force", "--no-sign-request"],
+            [
+                sys.executable,
+                "-m",
+                "s3lfs.cli",
+                "cleanup",
+                "--force",
+                "--no-sign-request",
+            ],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -774,7 +796,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test track command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "track", "test_file.txt"],
+                [sys.executable, "-m", "s3lfs.cli", "track", "test_file.txt"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -798,7 +820,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test track command with --modified flag when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "track", "--modified"],
+                [sys.executable, "-m", "s3lfs.cli", "track", "--modified"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -822,7 +844,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test checkout command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "checkout", "test_file.txt"],
+                [sys.executable, "-m", "s3lfs.cli", "checkout", "test_file.txt"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -846,7 +868,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test checkout command with --all flag when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "checkout", "--all"],
+                [sys.executable, "-m", "s3lfs.cli", "checkout", "--all"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -870,7 +892,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test ls command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "ls"],
+                [sys.executable, "-m", "s3lfs.cli", "ls"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -894,7 +916,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test ls command with --all flag when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "ls", "--all"],
+                [sys.executable, "-m", "s3lfs.cli", "ls", "--all"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -918,7 +940,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test remove command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "remove", "test_file.txt"],
+                [sys.executable, "-m", "s3lfs.cli", "remove", "test_file.txt"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -943,7 +965,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
             # Test remove command with --purge-from-s3 flag when not in git repo
             result = subprocess.run(
                 [
-                    "python",
+                    sys.executable,
                     "-m",
                     "s3lfs.cli",
                     "remove",
@@ -973,7 +995,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test cleanup command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "cleanup"],
+                [sys.executable, "-m", "s3lfs.cli", "cleanup"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -997,7 +1019,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test cleanup command with --force flag when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "cleanup", "--force"],
+                [sys.executable, "-m", "s3lfs.cli", "cleanup", "--force"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,


### PR DESCRIPTION
Fixes #86. Re-lands the content of #93 against `main`.

#93 was merged into `cleanup-structure`, which was subsequently bypassed when the rest of the work was rebased onto `main`. The fix never reached `main` as a result, so this is the same change applied directly.

## The problem

62 tests spawn a subprocess with the literal executable name `python`, which does not exist on modern macOS or on many Linux distributions where only `python3` is installed.

CI does not catch it: `uv sync` provides a venv in which `python` resolves. The breakage is invisible in CI and hits anyone running `pytest` directly.

## Effect

On `main`, locally: `61 failed / 592 passed` → **`653 passed, 0 failed`**.

| File | Was failing |
| --- | --- |
| `tests/test_manifest_not_exists_coverage.py` | 39 |
| `tests/test_ls_command_coverage.py` | 13 |
| `tests/test_git_root_coverage.py` | 9 |

`sys.executable` is correct regardless of environment and additionally guarantees the subprocess runs under the same interpreter as the test, rather than whichever `python` happens to be first on `PATH`.

## Notes

- `tests/test_s3lfs.py`'s `method="python"` is deliberately untouched — that names a compression backend, not an interpreter.
- Some lines needed rewrapping, since `sys.executable` is longer than `"python"` and pushed them past black's 88-char limit. That is the whole of the non-mechanical diff.
- The CI-trigger widening that accompanied #93 is already on `main`, so it is not repeated here.

## Why it matters beyond convenience

A suite with 61 permanent failures cannot be used as a local signal. During this work I misread a baseline for exactly that reason — comparing against a tree built with `git archive` (which omits `.git`) and wrongly concluding a change had fixed 28 tests. Constant background noise makes that class of error easy to make and hard to notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UrDtdFKGwQZp8oYGwL2rj