### PR TITLE
Upload at commit time, verify at push, and keep tracked files out of git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `s3lfs verify` command: checks that manifest entries reference content that exists in S3, with `--revision` to verify a committed manifest and `--base` to verify only the entries a push introduces
+- `s3lfs pre-commit` command and pre-commit git hook: uploads modified tracked files and stages the updated manifest at commit time, so every commit's manifest matches the content in S3; blocks the commit if an s3lfs-tracked file is staged for commit in git itself
+- `s3lfs track` now adds tracked paths to a marked block in `.gitignore` and removes already-committed tracked files from the git index, preventing large files from entering git history; `s3lfs remove` removes the `.gitignore` entry
+
+### Changed
+- The pre-push hook now verifies that pushed manifests reference uploaded content (`s3lfs verify`) instead of uploading at push time. Uploading during pre-push updated only the working-tree manifest, so the commits being pushed still referenced the old hashes; uploads now happen in the pre-commit hook where the manifest change lands in the commit itself.
+
 ## [0.2.0] - 2026-04-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A Python-based version control system for large assets using Amazon S3 and S3-co
 - Works with any S3-compatible storage (MinIO, Cloudflare R2, Backblaze B2, Wasabi)
 - **Block-level parallel transfers**: Downloads and uploads flatten all chunks across all files into a single worker pool
 - **Automatic parallel compression**: Uses pigz when available, falls back to gzip
-- **Git hook integration**: `s3lfs install` sets up post-checkout, post-merge, and pre-push hooks
+- **Git hook integration**: `s3lfs install` sets up pre-commit, post-checkout, post-merge, and pre-push hooks
+- **Accident-proof tracking**: `s3lfs track` gitignores tracked paths and removes them from the git index, so large files can't sneak into git history
 - **Git LFS migration**: One-command migration with `s3lfs migrate-from-lfs`
 - **GitHub Action**: Built-in CI/CD support with selective checkout
 - **Per-repo config**: `.s3lfsconfig` file for team-wide defaults
@@ -70,6 +71,8 @@ s3lfs track data/                        # Track entire directory
 s3lfs track "*.mp4"                      # Track all MP4 files
 s3lfs track --modified                   # Track only changed files
 ```
+
+**Git protection**: Tracking a path also adds it to a marked block in `.gitignore` (so `git add .` won't commit the large files to git) and, if any of the files were already committed to git, removes them from the git index (`git rm --cached`; the files stay on disk). `s3lfs remove` removes the corresponding `.gitignore` entry again.
 
 ### Checkout Files
 ```sh
@@ -156,18 +159,32 @@ s3lfs cleanup
 s3lfs cleanup --force                    # Clean up without confirmation
 ```
 
+### Verify Uploaded Content
+```sh
+s3lfs verify
+s3lfs verify --revision HEAD
+s3lfs verify --revision HEAD --base origin/main
+```
+**Description**: Checks that every manifest entry references content that actually exists in S3, and exits non-zero listing any entries whose content was never uploaded. This is what the pre-push hook runs for each pushed ref.
+
+**Options**:
+- `--revision REV`: Verify the manifest as committed at a git revision (default: the working tree manifest)
+- `--base REV`: Only verify entries added or changed relative to this revision's manifest (used by the pre-push hook to check just the entries the push introduces)
+- `--no-sign-request`, `--endpoint-url`, `--workers`: As in other commands
+
 ### Install Git Hooks
 ```sh
 s3lfs install
 ```
-**Description**: Installs git hooks for transparent s3lfs integration. After installation, tracked files are automatically downloaded after `git checkout` and `git merge`, and modified files are automatically uploaded before `git push`.
+**Description**: Installs git hooks for transparent s3lfs integration. After installation, modified tracked files are automatically uploaded and the manifest staged when you `git commit`, tracked files are automatically downloaded after `git checkout` and `git merge`, and `git push` verifies that every pushed manifest references content that actually exists in S3.
 
 **Installed hooks**:
+- `pre-commit`: Uploads modified tracked files and stages the updated manifest, so each commit's manifest matches the content in S3. Also blocks the commit if an s3lfs-tracked file is staged for commit in git itself.
 - `post-checkout`: Downloads tracked files after branch checkouts
 - `post-merge`: Downloads tracked files after merges
-- `pre-push`: Uploads modified tracked files before push
+- `pre-push`: Verifies the manifests being pushed reference uploaded content (runs `s3lfs verify` for each pushed ref); aborts the push if content is missing
 
-The hooks are non-blocking -- if s3lfs fails or is not available, the git operation continues with a warning. Hooks are appended to existing hook files, preserving any other hooks you have.
+The post-* hooks are non-blocking -- if s3lfs fails or is not available, the git operation continues with a warning. The pre-commit and pre-push hooks abort their git operation on failure (bypass with `--no-verify`), because committing or pushing a manifest whose hashes have no objects behind them breaks every collaborator's checkout. Hooks are appended to existing hook files, preserving any other hooks you have.
 
 ### Uninstall Git Hooks
 ```sh
@@ -220,7 +237,7 @@ For a Git LFS-like experience where files sync automatically:
 ```sh
 s3lfs install
 ```
-With hooks installed, `git pull` and `git checkout` automatically download tracked files, and `git push` automatically uploads modified files.
+With hooks installed, `git commit` automatically uploads modified tracked files and stages the manifest, `git pull` and `git checkout` automatically download tracked files, and `git push` verifies the pushed manifests reference uploaded content.
 
 ### 2. Track Large Files
 Instead of committing large files directly to Git, track them with S3LFS:
@@ -229,14 +246,16 @@ s3lfs track data/large_dataset.zip
 s3lfs track models/
 s3lfs track "*.mp4"
 ```
+Tracking uploads the files to S3, adds the paths to `.gitignore` so they can't be committed to git by accident, and removes them from the git index if they were previously committed (the files stay on disk).
 
 ### 3. Commit Changes
-After tracking files, commit the updated manifest:
+After tracking files, commit the updated manifest and `.gitignore`:
 ```sh
-git add .s3_manifest.yaml
+git add .s3_manifest.yaml .gitignore
 git commit -m "Track large files with S3LFS"
 git push
 ```
+With hooks installed, the pre-commit hook re-uploads any modified tracked files and stages the manifest for you, so `git commit` is enough for day-to-day changes.
 
 ### 4. Clone and Restore Files
 When cloning the repository, restore tracked files:

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -1,4 +1,5 @@
 import json
+import subprocess
 from pathlib import Path
 
 import click
@@ -211,6 +212,7 @@ def track(
         s3lfs.track(
             manifest_key, silence=not verbose, interleaved=True, use_cache=False
         )
+        _protect_tracked_path(git_root, s3lfs, manifest_key)
     else:
         click.echo("Error: Must provide either a path or use --modified flag")
         raise click.Abort()
@@ -415,6 +417,9 @@ def remove(path, purge_from_s3, no_sign_request, use_acceleration, endpoint_url)
         # The manifest_key is matched against manifest entries
         # Note: This is manifest-only; files on disk are not affected
         versioner.remove_subtree(manifest_key, keep_in_s3=not purge_from_s3)
+
+    if _remove_gitignore_entry(git_root, {f"/{manifest_key}", f"/{manifest_key}/"}):
+        click.echo(f"Removed '{manifest_key}' from the s3lfs block in .gitignore")
 
 
 @click.command()
@@ -771,6 +776,181 @@ def _remove_lfs_from_gitattributes(gitattributes_path, lfs_patterns):
     gitattributes_path.write_text(text)
 
 
+S3LFS_GITIGNORE_START = "# >>> s3lfs tracked files >>>"
+S3LFS_GITIGNORE_END = "# <<< s3lfs tracked files <<<"
+
+
+def _load_gitignore_block(git_root):
+    """Split .gitignore into (lines_before, block_entries, lines_after).
+
+    The s3lfs block is delimited by marker comments so entries can be
+    added and removed without disturbing the rest of the file.
+    """
+    gitignore = git_root / ".gitignore"
+    if not gitignore.exists():
+        return [], [], []
+    lines = gitignore.read_text().splitlines()
+    if S3LFS_GITIGNORE_START not in lines:
+        return lines, [], []
+    start = lines.index(S3LFS_GITIGNORE_START)
+    try:
+        end = lines.index(S3LFS_GITIGNORE_END, start)
+    except ValueError:
+        # Malformed block (no end marker): drop only the start marker and
+        # keep everything else out of the block rather than swallowing
+        # user content into it.
+        return lines[:start], [], lines[start + 1 :]
+    entries = [line for line in lines[start + 1 : end] if line.strip()]
+    return lines[:start], entries, lines[end + 1 :]
+
+
+def _save_gitignore_block(git_root, before, entries, after):
+    """Write .gitignore back with the s3lfs block holding these entries."""
+    gitignore = git_root / ".gitignore"
+    lines = list(before)
+    if entries:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.append(S3LFS_GITIGNORE_START)
+        lines.extend(entries)
+        lines.append(S3LFS_GITIGNORE_END)
+    lines.extend(after)
+    if not lines and not gitignore.exists():
+        return
+    gitignore.write_text("\n".join(lines) + ("\n" if lines else ""))
+
+
+def _add_gitignore_entry(git_root, entry):
+    """Add an entry to the s3lfs block in .gitignore. Returns True if added."""
+    before, entries, after = _load_gitignore_block(git_root)
+    if entry in entries:
+        return False
+    entries.append(entry)
+    _save_gitignore_block(git_root, before, entries, after)
+    return True
+
+
+def _remove_gitignore_entry(git_root, entry_variants):
+    """Remove any of these entries from the s3lfs block. Returns True if removed."""
+    before, entries, after = _load_gitignore_block(git_root)
+    kept = [e for e in entries if e not in entry_variants]
+    if kept == entries:
+        return False
+    _save_gitignore_block(git_root, before, kept, after)
+    return True
+
+
+def _gitignore_entry_for(git_root, manifest_key):
+    """Root-anchored .gitignore pattern covering a tracked path spec.
+
+    Manifest keys are relative to the git root, so anchoring with a
+    leading slash keeps the pattern from matching same-named paths in
+    other directories. Glob specs pass through: both glob.glob (used to
+    resolve them at track time) and gitignore give an unanchored '*' the
+    same single-level meaning.
+    """
+    if (git_root / manifest_key).is_dir():
+        return f"/{manifest_key}/"
+    return f"/{manifest_key}"
+
+
+def _deindex_tracked_files(git_root, tracked_keys):
+    """Drop s3lfs-tracked files from the git index; files stay on disk.
+
+    .gitignore has no effect on files git already tracks, so anything
+    committed before it was handed to s3lfs must be removed from the
+    index or git will keep versioning it alongside S3.
+
+    Returns the list of paths that were removed.
+    """
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        capture_output=True,
+        text=True,
+        cwd=str(git_root),
+    )
+    if result.returncode != 0:
+        return []
+    indexed = {p for p in result.stdout.split("\0") if p}
+    offenders = sorted(indexed & set(tracked_keys))
+    if not offenders:
+        return []
+    result = subprocess.run(
+        [
+            "git",
+            "rm",
+            "--cached",
+            # --force is index-only here: with --cached, git rm never touches
+            # the working copy. Without it, git refuses files whose staged
+            # content differs from HEAD.
+            "--force",
+            "--quiet",
+            "--pathspec-from-file=-",
+            "--pathspec-file-nul",
+        ],
+        input="\0".join(f":(literal){p}" for p in offenders),
+        capture_output=True,
+        text=True,
+        cwd=str(git_root),
+    )
+    if result.returncode != 0:
+        click.echo(
+            "Warning: failed to remove tracked files from the git index:\n"
+            f"{result.stderr.strip()}"
+        )
+        return []
+    return offenders
+
+
+def _protect_tracked_path(git_root, s3lfs, manifest_key):
+    """Keep a newly tracked path spec out of git: ignore it and de-index it."""
+    s3lfs.load_manifest()
+    matched = s3lfs._resolve_manifest_paths(manifest_key)
+    if not matched:
+        # The spec tracked nothing; leave git configuration alone.
+        return
+
+    entry = _gitignore_entry_for(git_root, manifest_key)
+    if _add_gitignore_entry(git_root, entry):
+        click.echo(f"Added '{entry}' to .gitignore (s3lfs block)")
+
+    removed = _deindex_tracked_files(git_root, matched.keys())
+    if removed:
+        click.echo(
+            f"Removed {len(removed)} s3lfs-tracked file(s) from the git index "
+            "(files remain on disk):"
+        )
+        for path in removed[:10]:
+            click.echo(f"  {path}")
+        if len(removed) > 10:
+            click.echo(f"  ... and {len(removed) - 10} more")
+        click.echo("Commit to finalize their removal from git.")
+
+
+def _manifest_files_at_revision(git_root, revision):
+    """Load the manifest's files mapping as of a git revision.
+
+    Returns None when the revision has no manifest or is not available
+    locally (e.g. a remote sha that was never fetched).
+    """
+    names = [get_manifest_path(git_root).name]
+    for other in (".s3_manifest.yaml", ".s3_manifest.json"):
+        if other not in names:
+            names.append(other)
+    for name in names:
+        result = subprocess.run(
+            ["git", "show", f"{revision}:{name}"],
+            capture_output=True,
+            text=True,
+            cwd=str(git_root),
+        )
+        if result.returncode == 0:
+            # yaml.safe_load handles both the YAML and JSON manifest formats
+            data = yaml.safe_load(result.stdout) or {}
+            return data.get("files") or {}
+    return None
+
+
 S3LFS_HOOK_START = "# >>> s3lfs hook >>>"
 S3LFS_HOOK_END = "# <<< s3lfs hook <<<"
 
@@ -793,20 +973,45 @@ if [ "$3" = "1" ] && command -v s3lfs >/dev/null 2>&1; then
     fi
 fi"""
 
-_PRE_PUSH_BODY = """\
-# Auto-track modified s3lfs files before push.
+_PRE_COMMIT_BODY = """\
+# Upload modified s3lfs files and stage the manifest before commit.
 #
-# This hook aborts the push on failure, and that is deliberate. It uploads
-# the content the manifest being pushed refers to; if the upload fails and
-# the push proceeds, collaborators fetch a manifest whose hashes have no
-# objects behind them and every checkout 404s. Failing here is recoverable,
-# pushing a broken manifest is not.
+# Running at commit time (not push time) keeps every commit self-consistent:
+# the commit that changes a tracked file is the commit whose manifest points
+# at the new hash, and the content is already in S3 by the time that commit
+# can be pushed. This hook also blocks committing s3lfs-tracked files into
+# git itself.
 if command -v s3lfs >/dev/null 2>&1; then
-    if ! s3lfs track --modified 2>&1; then
-        echo "s3lfs: pre-push track failed; aborting push" >&2
-        echo "s3lfs: push anyway with --no-verify if you are sure" >&2
+    if ! s3lfs pre-commit 2>&1; then
+        echo "s3lfs: pre-commit failed; aborting commit" >&2
+        echo "s3lfs: commit anyway with --no-verify if you are sure" >&2
         exit 1
     fi
+fi"""
+
+_PRE_PUSH_BODY = """\
+# Verify the manifests being pushed reference content that exists in S3.
+#
+# Uploads happen at commit time (pre-commit hook); this is the last line of
+# defense against publishing a manifest whose hashes have no objects behind
+# them (commits made with --no-verify, or before hooks were installed).
+# If the push proceeded anyway, every collaborator checkout would 404.
+if command -v s3lfs >/dev/null 2>&1; then
+    zero=0000000000000000000000000000000000000000
+    while read local_ref local_sha remote_ref remote_sha; do
+        [ "$local_sha" = "$zero" ] && continue
+        if [ "$remote_sha" = "$zero" ]; then
+            base_args=""
+        else
+            base_args="--base $remote_sha"
+        fi
+        if ! s3lfs verify --revision "$local_sha" $base_args 2>&1; then
+            echo "s3lfs: content referenced by this push is missing from S3; aborting push" >&2
+            echo "s3lfs: run 's3lfs track --modified', commit the manifest, and retry" >&2
+            echo "s3lfs: or push with --no-verify to skip this check" >&2
+            exit 1
+        fi
+    done
 fi"""
 
 HOOK_SCRIPTS = {
@@ -814,6 +1019,7 @@ HOOK_SCRIPTS = {
     "post-checkout": (
         S3LFS_HOOK_START + "\n" + _POST_CHECKOUT_BODY + "\n" + S3LFS_HOOK_END
     ),
+    "pre-commit": S3LFS_HOOK_START + "\n" + _PRE_COMMIT_BODY + "\n" + S3LFS_HOOK_END,
     "pre-push": S3LFS_HOOK_START + "\n" + _PRE_PUSH_BODY + "\n" + S3LFS_HOOK_END,
 }
 
@@ -933,9 +1139,13 @@ def install():
     click.echo()
     click.echo("s3lfs hooks installed. Your git workflow now automatically:")
     click.echo(
+        "  - Uploads modified files and stages the manifest on commit (pre-commit)"
+    )
+    click.echo("  - Blocks committing s3lfs-tracked files into git (pre-commit)")
+    click.echo(
         "  - Downloads tracked files after checkout/merge (post-checkout, post-merge)"
     )
-    click.echo("  - Uploads modified files before push (pre-push)")
+    click.echo("  - Verifies pushed manifests reference uploaded content (pre-push)")
     click.echo()
     click.echo("Run 's3lfs uninstall' to remove hooks.")
 
@@ -962,6 +1172,136 @@ def uninstall():
         click.echo("No s3lfs hooks found.")
 
 
+@click.command()
+@click.option(
+    "--revision",
+    default=None,
+    help="Git revision whose manifest to verify (default: working tree manifest)",
+)
+@click.option(
+    "--base",
+    default=None,
+    help="Only verify entries added or changed relative to this revision's manifest",
+)
+@click.option("--no-sign-request", is_flag=True, help="Use unsigned S3 requests")
+@click.option(
+    "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
+)
+@click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+@click.option(
+    "--workers",
+    type=int,
+    default=None,
+    help="Number of parallel workers (default: auto-detected from CPU count)",
+)
+def verify(revision, base, no_sign_request, use_acceleration, endpoint_url, workers):
+    """Verify that manifest entries have content behind them in S3.
+
+    Exits non-zero if any entry references content that was never uploaded.
+    Used by the pre-push hook to stop a push that would publish a manifest
+    whose hashes have no objects behind them.
+    """
+    git_root, manifest_path, path_resolver = _setup_s3lfs_command()
+
+    s3lfs = _make_s3lfs(
+        git_root,
+        manifest_path,
+        no_sign_request=no_sign_request,
+        use_acceleration=use_acceleration,
+        endpoint_url=endpoint_url,
+        workers=workers,
+    )
+
+    if revision:
+        files = _manifest_files_at_revision(git_root, revision)
+        if files is None:
+            click.echo(f"No manifest at revision {revision}; nothing to verify.")
+            return
+    else:
+        files = dict(s3lfs.manifest.get("files", {}))
+
+    if base:
+        base_files = _manifest_files_at_revision(git_root, base) or {}
+        files = {k: h for k, h in files.items() if base_files.get(k) != h}
+
+    if not files:
+        click.echo("No manifest entries to verify.")
+        return
+
+    noun = "entry" if len(files) == 1 else "entries"
+    click.echo(f"Verifying {len(files)} manifest {noun} against S3...")
+    missing = s3lfs.find_missing_assets(files)
+    if missing:
+        click.echo("Content missing from S3:")
+        for key, file_hash in sorted(missing):
+            click.echo(f"  {key} ({file_hash[:12]})")
+        click.echo(
+            f"Error: {len(missing)} of {len(files)} {noun} have no content in S3."
+        )
+        raise SystemExit(1)
+    click.echo(f"All {len(files)} {noun} verified present in S3.")
+
+
+@click.command("pre-commit")
+@click.option("--no-sign-request", is_flag=True, help="Use unsigned S3 requests")
+@click.option(
+    "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
+)
+@click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+def pre_commit(no_sign_request, use_acceleration, endpoint_url):
+    """Prepare a commit (run by the pre-commit git hook).
+
+    Blocks the commit if any staged file is tracked by s3lfs, uploads
+    modified tracked content, and stages the updated manifest so the
+    commit's manifest matches what is in S3.
+    """
+    git_root, manifest_path, path_resolver = _setup_s3lfs_command()
+
+    s3lfs = _make_s3lfs(
+        git_root,
+        manifest_path,
+        no_sign_request=no_sign_request,
+        use_acceleration=use_acceleration,
+        endpoint_url=endpoint_url,
+    )
+    tracked = set(s3lfs.manifest.get("files", {}))
+
+    result = subprocess.run(
+        ["git", "diff", "--cached", "--name-only", "--diff-filter=d", "-z"],
+        capture_output=True,
+        text=True,
+        cwd=str(git_root),
+    )
+    staged = {p for p in result.stdout.split("\0") if p}
+    offenders = sorted(staged & tracked)
+    if offenders:
+        click.echo(
+            "Error: these files are tracked by s3lfs but staged for commit in git:"
+        )
+        for path in offenders:
+            click.echo(f"  {path}")
+        click.echo("Unstage them (the files stay on disk):")
+        for path in offenders:
+            click.echo(f"  git rm --cached '{path}'")
+        raise SystemExit(1)
+
+    if tracked:
+        s3lfs.track_modified_files_cached(silence=True)
+
+    subprocess.run(
+        ["git", "add", "--", manifest_path.name],
+        cwd=str(git_root),
+    )
+
+
 cli.add_command(init)
 cli.add_command(track)
 cli.add_command(checkout)
@@ -972,6 +1312,8 @@ cli.add_command(migrate)
 cli.add_command(migrate_from_lfs)
 cli.add_command(install)
 cli.add_command(uninstall)
+cli.add_command(verify)
+cli.add_command(pre_commit)
 
 
 def main():

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -452,6 +452,38 @@ class S3LFS:
         head, sep, tail = key.rpartition(".chunk")
         return bool(sep) and tail.isdigit() and head in base_keys
 
+    def find_missing_assets(self, files):
+        """Return the manifest entries whose content is absent from S3.
+
+        :param files: dict of manifest_key -> file_hash to check
+        :return: list of (manifest_key, file_hash) tuples with no object behind them
+
+        An entry is present if its base key exists, or at least one of its
+        chunks does (a large file is stored only as base_key.chunk0..N).
+        Chunk completeness is not verified; this answers "was this content
+        ever uploaded", which is what push-time verification needs.
+        """
+
+        @retry(3, (BotoCoreError, ClientError, SSLError))
+        def check(item):
+            manifest_key, file_hash = item
+            base_key = self._asset_base_key(manifest_key, file_hash)
+            resp = self._get_s3_client().list_objects_v2(
+                Bucket=self.bucket_name, Prefix=base_key
+            )
+            keys = [obj["Key"] for obj in resp.get("Contents", [])]
+            # A prefix match can hit an unrelated, longer key.
+            if any(self._key_covered_by(k, {base_key}) for k in keys):
+                return None
+            return item
+
+        if not files:
+            return []
+
+        with ThreadPoolExecutor(max_workers=self.workers) as pool:
+            results = list(pool.map(check, files.items()))
+        return [item for item in results if item is not None]
+
     def _get_s3_client(self):
         """Ensures each thread gets its own instance of the S3 client with appropriate authentication handling."""
         if not hasattr(self.thread_local, "s3"):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+REPO_GITIGNORE = Path(__file__).resolve().parent.parent / ".gitignore"
+
+
+@pytest.fixture(autouse=True)
+def preserve_repo_gitignore():
+    """Some CLI tests run s3lfs commands in the repository's own working
+    directory, and those commands edit .gitignore by design (cache
+    exclusions on init, tracked-path entries on track). Restore the repo's
+    .gitignore afterwards so test runs don't dirty the developer's tree.
+    Tests operating in temp dirs are unaffected."""
+    original = REPO_GITIGNORE.read_text() if REPO_GITIGNORE.exists() else None
+    yield
+    if original is None:
+        if REPO_GITIGNORE.exists():
+            REPO_GITIGNORE.unlink()
+    elif not REPO_GITIGNORE.exists() or REPO_GITIGNORE.read_text() != original:
+        REPO_GITIGNORE.write_text(original)

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -1,0 +1,333 @@
+"""Tests for the git-workflow integration: .gitignore protection of tracked
+paths, the pre-commit command, and push-time verification."""
+
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import boto3
+from click.testing import CliRunner
+from moto import mock_s3
+
+from s3lfs.cli import (
+    S3LFS_GITIGNORE_END,
+    S3LFS_GITIGNORE_START,
+    _add_gitignore_entry,
+    _load_gitignore_block,
+    _remove_gitignore_entry,
+    cli,
+)
+
+TEST_BUCKET = "test-bucket-s3lfs-git"
+
+
+class TestGitignoreBlockHelpers(unittest.TestCase):
+    """The s3lfs block in .gitignore must not disturb surrounding content."""
+
+    def setUp(self):
+        self.temp_dir = Path(os.path.realpath(tempfile.mkdtemp()))
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_add_creates_block(self):
+        added = _add_gitignore_entry(self.temp_dir, "/data/")
+        self.assertTrue(added)
+        content = (self.temp_dir / ".gitignore").read_text()
+        self.assertIn(S3LFS_GITIGNORE_START, content)
+        self.assertIn("/data/", content)
+        self.assertIn(S3LFS_GITIGNORE_END, content)
+
+    def test_add_is_idempotent(self):
+        _add_gitignore_entry(self.temp_dir, "/data/")
+        added = _add_gitignore_entry(self.temp_dir, "/data/")
+        self.assertFalse(added)
+        content = (self.temp_dir / ".gitignore").read_text()
+        self.assertEqual(content.count("/data/"), 1)
+
+    def test_add_preserves_existing_content(self):
+        (self.temp_dir / ".gitignore").write_text("*.pyc\n")
+        _add_gitignore_entry(self.temp_dir, "/data/")
+        content = (self.temp_dir / ".gitignore").read_text()
+        self.assertIn("*.pyc", content)
+        self.assertLess(content.index("*.pyc"), content.index("/data/"))
+
+    def test_remove_deletes_entry_and_empty_block(self):
+        (self.temp_dir / ".gitignore").write_text("*.pyc\n")
+        _add_gitignore_entry(self.temp_dir, "/data/")
+        removed = _remove_gitignore_entry(self.temp_dir, {"/data/", "/data"})
+        self.assertTrue(removed)
+        content = (self.temp_dir / ".gitignore").read_text()
+        self.assertIn("*.pyc", content)
+        self.assertNotIn("/data/", content)
+        self.assertNotIn(S3LFS_GITIGNORE_START, content)
+
+    def test_remove_keeps_other_entries(self):
+        _add_gitignore_entry(self.temp_dir, "/data/")
+        _add_gitignore_entry(self.temp_dir, "/models/big.bin")
+        _remove_gitignore_entry(self.temp_dir, {"/data/", "/data"})
+        content = (self.temp_dir / ".gitignore").read_text()
+        self.assertNotIn("/data/", content)
+        self.assertIn("/models/big.bin", content)
+
+    def test_remove_missing_entry_returns_false(self):
+        _add_gitignore_entry(self.temp_dir, "/data/")
+        self.assertFalse(_remove_gitignore_entry(self.temp_dir, {"/other"}))
+
+    def test_content_after_block_is_preserved(self):
+        _add_gitignore_entry(self.temp_dir, "/data/")
+        with open(self.temp_dir / ".gitignore", "a") as f:
+            f.write("*.log\n")
+        _add_gitignore_entry(self.temp_dir, "/models/")
+        before, entries, after = _load_gitignore_block(self.temp_dir)
+        self.assertEqual(entries, ["/data/", "/models/"])
+        self.assertIn("*.log", after)
+
+
+class GitRepoTestCase(unittest.TestCase):
+    """Base: a real temp git repo with an initialized s3lfs manifest.
+
+    moto is started explicitly here (not via the class decorator) because
+    the decorator does not wrap a setUp inherited from a base class.
+    """
+
+    def setUp(self):
+        self.mock_s3 = mock_s3()
+        self.mock_s3.start()
+        self.addCleanup(self.mock_s3.stop)
+
+        self.temp_dir = os.path.realpath(tempfile.mkdtemp())
+        self.original_cwd = os.getcwd()
+        os.chdir(self.temp_dir)
+
+        subprocess.run(["git", "init"], capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"], capture_output=True
+        )
+        subprocess.run(["git", "config", "user.name", "Test"], capture_output=True)
+
+        self.s3 = boto3.client("s3", region_name="us-east-1")
+        self.s3.create_bucket(Bucket=TEST_BUCKET)
+
+        self.runner = CliRunner()
+        result = self.runner.invoke(cli, ["init", TEST_BUCKET, "test-prefix"])
+        assert result.exit_code == 0, result.output
+
+    def tearDown(self):
+        os.chdir(self.original_cwd)
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _git(self, *args):
+        return subprocess.run(
+            ["git", *args], capture_output=True, text=True, cwd=self.temp_dir
+        )
+
+    def _git_files(self):
+        return set(self._git("ls-files").stdout.splitlines())
+
+    def _commit_all(self, message="commit"):
+        self._git("add", "-A")
+        self._git("commit", "-m", message)
+
+    def _write(self, rel_path, content):
+        path = Path(self.temp_dir) / rel_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+
+class TestTrackProtectsFromGit(GitRepoTestCase):
+    """Tracking a path must keep it out of git: ignored and de-indexed."""
+
+    def test_track_file_adds_gitignore_entry(self):
+        self._write("data/big.bin", "payload")
+        result = self.runner.invoke(cli, ["track", "data/big.bin"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        content = Path(".gitignore").read_text()
+        self.assertIn(S3LFS_GITIGNORE_START, content)
+        self.assertIn("/data/big.bin", content)
+        # git must now consider the file ignored
+        check = self._git("check-ignore", "data/big.bin")
+        self.assertEqual(check.returncode, 0, "tracked file is not gitignored")
+
+    def test_track_directory_adds_anchored_dir_entry(self):
+        self._write("data/a.bin", "a")
+        self._write("data/sub/b.bin", "b")
+        result = self.runner.invoke(cli, ["track", "data"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        _, entries, _ = _load_gitignore_block(Path(self.temp_dir))
+        self.assertIn("/data/", entries)
+        self.assertEqual(self._git("check-ignore", "data/sub/b.bin").returncode, 0)
+
+    def test_track_removes_committed_file_from_index(self):
+        """A file already committed to git is de-indexed when handed to s3lfs.
+
+        .gitignore has no effect on files git already tracks, so without
+        this step git would keep versioning the large file alongside S3.
+        """
+        self._write("data/big.bin", "payload")
+        self._commit_all("add big file to git")
+        self.assertIn("data/big.bin", self._git_files())
+
+        result = self.runner.invoke(cli, ["track", "data/big.bin"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        self.assertNotIn("data/big.bin", self._git_files())
+        self.assertTrue(Path("data/big.bin").exists(), "file must stay on disk")
+        self.assertIn("Removed 1 s3lfs-tracked file(s)", result.output)
+
+    def test_track_deindexes_file_with_staged_changes(self):
+        """git rm --cached needs --force when staged content differs from
+        HEAD; the de-index must still work and must not delete the file."""
+        self._write("data/big.bin", "v1")
+        self._commit_all("add big file to git")
+        self._write("data/big.bin", "v2")
+        self._git("add", "data/big.bin")
+
+        result = self.runner.invoke(cli, ["track", "data/big.bin"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        self.assertNotIn("data/big.bin", self._git_files())
+        self.assertEqual(Path("data/big.bin").read_text(), "v2")
+
+    def test_track_never_tracked_path_leaves_git_alone(self):
+        """Tracking a path that matches nothing must not touch .gitignore."""
+        self.runner.invoke(cli, ["track", "no/such/file.bin"])
+
+        _, entries, _ = _load_gitignore_block(Path(self.temp_dir))
+        self.assertEqual(entries, [])
+
+    def test_remove_drops_gitignore_entry(self):
+        self._write("data/big.bin", "payload")
+        self.runner.invoke(cli, ["track", "data/big.bin"])
+        result = self.runner.invoke(cli, ["remove", "data/big.bin"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        _, entries, _ = _load_gitignore_block(Path(self.temp_dir))
+        self.assertNotIn("/data/big.bin", entries)
+
+
+class TestPreCommitCommand(GitRepoTestCase):
+    """s3lfs pre-commit: block staged tracked files, upload, stage manifest."""
+
+    def test_blocks_staged_tracked_file(self):
+        self._write("data/big.bin", "payload")
+        self.runner.invoke(cli, ["track", "data/big.bin"])
+        # Force-stage the tracked file past .gitignore
+        self._git("add", "-f", "data/big.bin")
+
+        result = self.runner.invoke(cli, ["pre-commit"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("data/big.bin", result.output)
+        self.assertIn("git rm --cached", result.output)
+
+    def test_uploads_modified_content_and_stages_manifest(self):
+        self._write("data/big.bin", "v1")
+        self.runner.invoke(cli, ["track", "data/big.bin"])
+        self._commit_all("track big file")
+
+        self._write("data/big.bin", "v2")
+        result = self.runner.invoke(cli, ["pre-commit"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        # Manifest reflects the new content and is staged for the commit
+        staged = self._git("diff", "--cached", "--name-only").stdout.splitlines()
+        self.assertIn(".s3_manifest.yaml", staged)
+        # The new content must already be in S3: verify succeeds
+        verify = self.runner.invoke(cli, ["verify"])
+        self.assertEqual(verify.exit_code, 0, msg=verify.output)
+
+    def test_noop_when_nothing_modified(self):
+        self._write("data/big.bin", "v1")
+        self.runner.invoke(cli, ["track", "data/big.bin"])
+        self._commit_all("track big file")
+
+        result = self.runner.invoke(cli, ["pre-commit"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+
+class TestVerifyCommand(GitRepoTestCase):
+    """s3lfs verify: does the manifest reference content that exists in S3?"""
+
+    def _delete_all_objects(self):
+        resp = self.s3.list_objects_v2(Bucket=TEST_BUCKET)
+        for obj in resp.get("Contents", []):
+            self.s3.delete_object(Bucket=TEST_BUCKET, Key=obj["Key"])
+
+    def test_verify_passes_after_track(self):
+        self._write("data/big.bin", "payload")
+        self.runner.invoke(cli, ["track", "data/big.bin"])
+
+        result = self.runner.invoke(cli, ["verify"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("verified present", result.output)
+
+    def test_verify_fails_when_content_missing(self):
+        self._write("data/big.bin", "payload")
+        self.runner.invoke(cli, ["track", "data/big.bin"])
+        self._delete_all_objects()
+
+        result = self.runner.invoke(cli, ["verify"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("data/big.bin", result.output)
+
+    def test_verify_revision_reads_committed_manifest(self):
+        self._write("data/big.bin", "payload")
+        self.runner.invoke(cli, ["track", "data/big.bin"])
+        self._commit_all("track big file")
+
+        result = self.runner.invoke(cli, ["verify", "--revision", "HEAD"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("verified present", result.output)
+
+    def test_verify_base_skips_unchanged_entries(self):
+        self._write("data/big.bin", "payload")
+        self.runner.invoke(cli, ["track", "data/big.bin"])
+        self._commit_all("track big file")
+
+        # Base == revision: every entry is unchanged, nothing to check,
+        # even if the content has vanished from S3.
+        self._delete_all_objects()
+        result = self.runner.invoke(
+            cli, ["verify", "--revision", "HEAD", "--base", "HEAD"]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("No manifest entries to verify", result.output)
+
+    def test_verify_base_catches_changed_entries(self):
+        self._write("data/big.bin", "v1")
+        self.runner.invoke(cli, ["track", "data/big.bin"])
+        self._commit_all("track v1")
+
+        self._write("data/big.bin", "v2")
+        self.runner.invoke(cli, ["track", "data/big.bin"])
+        self._commit_all("track v2")
+        self._delete_all_objects()
+
+        result = self.runner.invoke(
+            cli, ["verify", "--revision", "HEAD", "--base", "HEAD~1"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("data/big.bin", result.output)
+
+    def test_verify_revision_without_manifest(self):
+        """A revision predating s3lfs init has nothing to verify."""
+        # Remove the manifest and commit an unrelated file
+        Path(".s3_manifest.yaml").unlink()
+        self._write("readme.txt", "hello")
+        self._commit_all("no manifest yet")
+        # Re-initialize so the working tree has a manifest again
+        self.runner.invoke(cli, ["init", TEST_BUCKET, "test-prefix"])
+
+        result = self.runner.invoke(cli, ["verify", "--revision", "HEAD"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("No manifest at revision", result.output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_git_root_coverage.py
+++ b/tests/test_git_root_coverage.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -46,7 +47,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from outside git repo
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=outside_dir,
@@ -81,7 +82,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from different level directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=different_level_dir,
@@ -114,7 +115,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from parent directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=parent_dir,
@@ -148,7 +149,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from sibling directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=sibling_dir,
@@ -182,7 +183,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from nested directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=nested_dir,
@@ -219,7 +220,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from symlink directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=symlink_dir,
@@ -253,7 +254,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from absolute path directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=outside_dir,
@@ -293,7 +294,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
                 # Test ls command from different drive directory
                 result = subprocess.run(
-                    ["python", "-m", "s3lfs.cli", "ls"],
+                    [sys.executable, "-m", "s3lfs.cli", "ls"],
                     capture_output=True,
                     text=True,
                     cwd=different_drive_dir,
@@ -310,7 +311,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
             # Test ls command from different drive directory
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "ls"],
+                [sys.executable, "-m", "s3lfs.cli", "ls"],
                 capture_output=True,
                 text=True,
                 cwd=different_drive_dir,
@@ -346,7 +347,7 @@ class TestGitRootCoverage(unittest.TestCase):
 
         # Test ls command from outside directory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=outside_dir,

--- a/tests/test_hook_behaviour.py
+++ b/tests/test_hook_behaviour.py
@@ -10,12 +10,20 @@ from s3lfs.cli import HOOK_SCRIPTS, _install_hook, _uninstall_hook
 
 
 class TestHookExitStatus(unittest.TestCase):
-    """pre-push must abort the push when tracking fails.
+    """The blocking hooks must abort their git operation when s3lfs fails.
 
-    pre-push uploads the content the manifest being pushed refers to. If the
-    upload fails and the push proceeds, collaborators fetch a manifest whose
+    pre-commit uploads the content the commit's manifest refers to, and
+    pre-push verifies pushed manifests reference uploaded content. Letting
+    either git operation proceed after a failure publishes a manifest whose
     hashes have no objects behind them.
     """
+
+    # A pre-push hook receives one "<local_ref> <local_sha> <remote_ref>
+    # <remote_sha>" line per ref being pushed on stdin.
+    PUSH_REF_LINE = (
+        "refs/heads/main aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa "
+        "refs/heads/main bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+    )
 
     def setUp(self):
         self.temp_dir = tempfile.mkdtemp()
@@ -39,7 +47,7 @@ class TestHookExitStatus(unittest.TestCase):
         env["PATH"] = f"{self.bin_dir}:{env['PATH']}"
         return env
 
-    def _run_hook(self, hook_name, exit_code, args=()):
+    def _run_hook(self, hook_name, exit_code, args=(), stdin=""):
         env = self._fake_s3lfs(exit_code)
         hook_path = _install_hook(self.hooks_dir, hook_name, HOOK_SCRIPTS[hook_name])
         return subprocess.run(
@@ -47,17 +55,40 @@ class TestHookExitStatus(unittest.TestCase):
             capture_output=True,
             text=True,
             env=env,
+            input=stdin,
         )
 
-    def test_pre_push_fails_when_track_fails(self):
-        result = self._run_hook("pre-push", exit_code=1)
+    def test_pre_push_fails_when_verify_fails(self):
+        result = self._run_hook("pre-push", exit_code=1, stdin=self.PUSH_REF_LINE)
         self.assertNotEqual(
-            result.returncode, 0, "pre-push masked a failed track and allowed the push"
+            result.returncode,
+            0,
+            "pre-push masked a failed verification and allowed the push",
         )
         self.assertIn("aborting push", result.stderr)
 
-    def test_pre_push_succeeds_when_track_succeeds(self):
-        result = self._run_hook("pre-push", exit_code=0)
+    def test_pre_push_succeeds_when_verify_succeeds(self):
+        result = self._run_hook("pre-push", exit_code=0, stdin=self.PUSH_REF_LINE)
+        self.assertEqual(result.returncode, 0)
+
+    def test_pre_push_skips_deleted_refs(self):
+        """Deleting a remote branch pushes a zero local sha; nothing to verify."""
+        zero = "0" * 40
+        line = f"(delete) {zero} refs/heads/gone bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\n"
+        result = self._run_hook("pre-push", exit_code=1, stdin=line)
+        self.assertEqual(result.returncode, 0)
+
+    def test_pre_commit_fails_when_s3lfs_fails(self):
+        result = self._run_hook("pre-commit", exit_code=1)
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            "pre-commit masked a failed upload and allowed the commit",
+        )
+        self.assertIn("aborting commit", result.stderr)
+
+    def test_pre_commit_succeeds_when_s3lfs_succeeds(self):
+        result = self._run_hook("pre-commit", exit_code=0)
         self.assertEqual(result.returncode, 0)
 
     def test_post_merge_does_not_fail_the_merge(self):

--- a/tests/test_install_hooks.py
+++ b/tests/test_install_hooks.py
@@ -199,14 +199,14 @@ class TestInstallCommand(unittest.TestCase):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def test_install_creates_all_hooks(self):
-        """Install command creates post-merge, post-checkout, and pre-push hooks."""
+        """Install command creates post-merge, post-checkout, pre-commit, and pre-push hooks."""
         runner = CliRunner()
         result = runner.invoke(cli, ["install"])
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
 
         hooks_dir = Path(self.temp_dir) / ".git" / "hooks"
-        for hook_name in ["post-merge", "post-checkout", "pre-push"]:
+        for hook_name in ["post-merge", "post-checkout", "pre-commit", "pre-push"]:
             hook_path = hooks_dir / hook_name
             self.assertTrue(hook_path.exists(), f"{hook_name} not created")
             content = hook_path.read_text()
@@ -220,6 +220,7 @@ class TestInstallCommand(unittest.TestCase):
 
         self.assertIn("post-merge", result.output)
         self.assertIn("post-checkout", result.output)
+        self.assertIn("pre-commit", result.output)
         self.assertIn("pre-push", result.output)
 
     def test_install_fails_without_manifest(self):
@@ -280,9 +281,9 @@ class TestInstallCommand(unittest.TestCase):
     def test_pre_push_aborts_on_failure(self):
         """pre-push is the last point at which a bad push can be stopped.
 
-        It uploads the content the manifest being pushed refers to; letting
-        the push proceed after a failed upload publishes a manifest whose
-        hashes have no objects behind them.
+        It verifies the manifests being pushed reference uploaded content;
+        letting the push proceed after a failed verification publishes a
+        manifest whose hashes have no objects behind them.
         """
         runner = CliRunner()
         runner.invoke(cli, ["install"])
@@ -290,12 +291,21 @@ class TestInstallCommand(unittest.TestCase):
         content = (Path(self.temp_dir) / ".git" / "hooks" / "pre-push").read_text()
         self.assertIn("exit 1", content)
 
+    def test_pre_commit_aborts_on_failure(self):
+        """pre-commit uploads the content the commit's manifest refers to;
+        a failed upload must abort the commit."""
+        runner = CliRunner()
+        runner.invoke(cli, ["install"])
+
+        content = (Path(self.temp_dir) / ".git" / "hooks" / "pre-commit").read_text()
+        self.assertIn("exit 1", content)
+
     def test_hooks_check_s3lfs_exists(self):
         """Hook scripts check that s3lfs command exists before running."""
         runner = CliRunner()
         runner.invoke(cli, ["install"])
 
-        for hook_name in ["post-merge", "post-checkout", "pre-push"]:
+        for hook_name in ["post-merge", "post-checkout", "pre-commit", "pre-push"]:
             hook_path = Path(self.temp_dir) / ".git" / "hooks" / hook_name
             content = hook_path.read_text()
             self.assertIn("command -v s3lfs", content)
@@ -332,7 +342,7 @@ class TestUninstallCommand(unittest.TestCase):
         self.assertIn("Removed", result.output)
 
         hooks_dir = Path(self.temp_dir) / ".git" / "hooks"
-        for hook_name in ["post-merge", "post-checkout", "pre-push"]:
+        for hook_name in ["post-merge", "post-checkout", "pre-commit", "pre-push"]:
             hook_path = hooks_dir / hook_name
             if hook_path.exists():
                 content = hook_path.read_text()

--- a/tests/test_ls_command_coverage.py
+++ b/tests/test_ls_command_coverage.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -30,7 +31,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command when not in git repo
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=non_git_dir,
@@ -51,7 +52,7 @@ class TestLSCommandCoverage(unittest.TestCase):
         # Don't create manifest file - it shouldn't exist
         # Test ls command when manifest doesn't exist
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -87,7 +88,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command from outside git repo
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=outside_dir,
@@ -117,7 +118,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with --all flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--all"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--all"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -146,7 +147,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with specific path
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -175,7 +176,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with --verbose flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--verbose"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--verbose"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -204,7 +205,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with --no-sign-request flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--no-sign-request"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--no-sign-request"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -234,7 +235,7 @@ class TestLSCommandCoverage(unittest.TestCase):
         # Test ls command with multiple flags
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "s3lfs.cli",
                 "ls",
@@ -270,7 +271,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with both path and --all flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "test_file.txt", "--all"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "test_file.txt", "--all"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -304,7 +305,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command from subdirectory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=subdir,
@@ -338,7 +339,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with specific path from subdirectory
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=subdir,
@@ -367,7 +368,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with empty manifest
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -396,7 +397,7 @@ class TestLSCommandCoverage(unittest.TestCase):
 
         # Test ls command with nonexistent path
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "nonexistent_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "nonexistent_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,

--- a/tests/test_manifest_not_exists_coverage.py
+++ b/tests/test_manifest_not_exists_coverage.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+import sys
 import tempfile
 import unittest
 
@@ -31,7 +32,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test track command without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "track", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "track", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -53,7 +54,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test track command with --modified flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "track", "--modified"],
+            [sys.executable, "-m", "s3lfs.cli", "track", "--modified"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -75,7 +76,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test track command with --verbose flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "track", "--verbose", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "track", "--verbose", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -98,7 +99,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         # Test track command with --no-sign-request flag without manifest file
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "s3lfs.cli",
                 "track",
@@ -126,7 +127,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test checkout command without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "checkout", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "checkout", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -148,7 +149,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test checkout command with --all flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "checkout", "--all"],
+            [sys.executable, "-m", "s3lfs.cli", "checkout", "--all"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -170,7 +171,14 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test checkout command with --verbose flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "checkout", "--verbose", "test_file.txt"],
+            [
+                sys.executable,
+                "-m",
+                "s3lfs.cli",
+                "checkout",
+                "--verbose",
+                "test_file.txt",
+            ],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -193,7 +201,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         # Test checkout command with --no-sign-request flag without manifest file
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "s3lfs.cli",
                 "checkout",
@@ -221,7 +229,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls"],
+            [sys.executable, "-m", "s3lfs.cli", "ls"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -243,7 +251,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --all flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--all"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--all"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -265,7 +273,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --verbose flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--verbose"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--verbose"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -287,7 +295,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --no-sign-request flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--no-sign-request"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--no-sign-request"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -309,7 +317,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test remove command without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "remove", "test_file.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "remove", "test_file.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -331,7 +339,14 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test remove command with --purge-from-s3 flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "remove", "--purge-from-s3", "test_file.txt"],
+            [
+                sys.executable,
+                "-m",
+                "s3lfs.cli",
+                "remove",
+                "--purge-from-s3",
+                "test_file.txt",
+            ],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -353,7 +368,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test cleanup command without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "cleanup"],
+            [sys.executable, "-m", "s3lfs.cli", "cleanup"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -375,7 +390,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test cleanup command with --force flag without manifest file
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "cleanup", "--force"],
+            [sys.executable, "-m", "s3lfs.cli", "cleanup", "--force"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -397,7 +412,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test init command
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "init", "testbucket", "testprefix"],
+            [sys.executable, "-m", "s3lfs.cli", "init", "testbucket", "testprefix"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -417,7 +432,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         # Test init command with --no-sign-request flag
         result = subprocess.run(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "s3lfs.cli",
                 "init",
@@ -447,7 +462,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test init command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "init", "testbucket", "testprefix"],
+                [sys.executable, "-m", "s3lfs.cli", "init", "testbucket", "testprefix"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -472,7 +487,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
             # Test init command with --no-sign-request flag when not in git repo
             result = subprocess.run(
                 [
-                    "python",
+                    sys.executable,
                     "-m",
                     "s3lfs.cli",
                     "init",
@@ -509,7 +524,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test track command with no path and no --modified flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "track"],
+            [sys.executable, "-m", "s3lfs.cli", "track"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -541,7 +556,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test checkout command with no path and no --all flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "checkout"],
+            [sys.executable, "-m", "s3lfs.cli", "checkout"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -573,7 +588,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --all flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--all"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--all"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -602,7 +617,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --all flag and --verbose
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--all", "--verbose"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--all", "--verbose"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -631,7 +646,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test ls command with --all flag and --no-sign-request
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "ls", "--all", "--no-sign-request"],
+            [sys.executable, "-m", "s3lfs.cli", "ls", "--all", "--no-sign-request"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -660,7 +675,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test remove command with directory pattern
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "remove", "test_dir/"],
+            [sys.executable, "-m", "s3lfs.cli", "remove", "test_dir/"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -689,7 +704,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test remove command with glob pattern
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "remove", "*.txt"],
+            [sys.executable, "-m", "s3lfs.cli", "remove", "*.txt"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -718,7 +733,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test cleanup command with --force flag
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "cleanup", "--force"],
+            [sys.executable, "-m", "s3lfs.cli", "cleanup", "--force"],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -749,7 +764,14 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
 
         # Test cleanup command with --force flag and --no-sign-request
         result = subprocess.run(
-            ["python", "-m", "s3lfs.cli", "cleanup", "--force", "--no-sign-request"],
+            [
+                sys.executable,
+                "-m",
+                "s3lfs.cli",
+                "cleanup",
+                "--force",
+                "--no-sign-request",
+            ],
             capture_output=True,
             text=True,
             cwd=git_repo,
@@ -774,7 +796,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test track command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "track", "test_file.txt"],
+                [sys.executable, "-m", "s3lfs.cli", "track", "test_file.txt"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -798,7 +820,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test track command with --modified flag when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "track", "--modified"],
+                [sys.executable, "-m", "s3lfs.cli", "track", "--modified"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -822,7 +844,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test checkout command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "checkout", "test_file.txt"],
+                [sys.executable, "-m", "s3lfs.cli", "checkout", "test_file.txt"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -846,7 +868,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test checkout command with --all flag when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "checkout", "--all"],
+                [sys.executable, "-m", "s3lfs.cli", "checkout", "--all"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -870,7 +892,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test ls command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "ls"],
+                [sys.executable, "-m", "s3lfs.cli", "ls"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -894,7 +916,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test ls command with --all flag when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "ls", "--all"],
+                [sys.executable, "-m", "s3lfs.cli", "ls", "--all"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -918,7 +940,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test remove command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "remove", "test_file.txt"],
+                [sys.executable, "-m", "s3lfs.cli", "remove", "test_file.txt"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -943,7 +965,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
             # Test remove command with --purge-from-s3 flag when not in git repo
             result = subprocess.run(
                 [
-                    "python",
+                    sys.executable,
                     "-m",
                     "s3lfs.cli",
                     "remove",
@@ -973,7 +995,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test cleanup command when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "cleanup"],
+                [sys.executable, "-m", "s3lfs.cli", "cleanup"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,
@@ -997,7 +1019,7 @@ class TestManifestNotExistsCoverage(unittest.TestCase):
         with patch("s3lfs.cli.find_git_root", return_value=None):
             # Test cleanup command with --force flag when not in git repo
             result = subprocess.run(
-                ["python", "-m", "s3lfs.cli", "cleanup", "--force"],
+                [sys.executable, "-m", "s3lfs.cli", "cleanup", "--force"],
                 capture_output=True,
                 text=True,
                 cwd=non_git_dir,


### PR DESCRIPTION
## Summary

Two git-workflow integration improvements that close the main gaps between s3lfs and a git-lfs-like experience:

### 1. Uploads move from pre-push to a new pre-commit hook

Uploading via `track --modified` at pre-push updated only the *working-tree* manifest — the commits being pushed still contained the old hashes, so the push succeeded and collaborators silently checked out stale content.

- New **`s3lfs pre-commit`** command + pre-commit hook: uploads modified tracked files and stages the updated manifest, so each commit's manifest matches what is in S3. Also blocks the commit if an s3lfs-tracked file is staged for commit in git itself.
- New **`s3lfs verify`** command backed by `S3LFS.find_missing_assets()`: parallel existence checks using the same path+hash key matching as GC. `--revision` reads the manifest out of a git revision; `--base` restricts checking to entries the push introduces.
- The **pre-push hook now verifies instead of uploading**: it reads the pushed refs from stdin and runs `s3lfs verify --revision <local_sha> --base <remote_sha>` per ref (full verify for new remote refs, skips deletions), aborting the push if referenced content is missing from S3. Bypass with `--no-verify`.

Re-running `s3lfs install` upgrades hooks in place (marker blocks are replaced).

### 2. `s3lfs track` keeps tracked files out of git

Previously nothing stopped `git add .` from committing a tracked 2 GB file into git history.

- `track` adds a root-anchored entry (`/data/`, `/models/big.bin`, globs pass through) to a marker-delimited s3lfs block in `.gitignore` — only when the spec actually tracked something.
- Files already committed to git are de-indexed with `git rm --cached --force` (index-only; files stay on disk, `--force` needed for staged changes).
- `s3lfs remove` removes the `.gitignore` entry again; the pre-commit guard is the backstop for `git add -f`.

## Caveat

`verify` confirms content was uploaded (base object or a chunk exists) but cannot validate chunk completeness for multi-chunk files, since the manifest doesn't record chunk counts — noted in the docstring.

## Testing

- New `tests/test_git_integration.py`: 22 tests covering the gitignore block helpers, de-indexing (incl. staged-changes case), pre-commit guard/upload/staging, and verify (incl. `--revision`/`--base`) against moto.
- Updated hook tests for the new hook set and stdin-driven pre-push.
- New `tests/conftest.py` autouse fixture restores the repo's own `.gitignore` after tests — legacy CLI tests run s3lfs commands in the repo cwd and would otherwise leave tracked-path entries behind.
- Full suite: 679 passed, 3 skipped; black/isort/flake8/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)