### PR TITLE
Add sync, status, clone, and a manifest merge driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `s3lfs sync [--from REV]` command: brings tracked files in line with the manifest by diffing against a revision's manifest, transferring only what changed and removing files the manifest no longer lists (only when their content still matches what it recorded). Replaces the blanket `checkout --all` in the post-checkout and post-merge hooks, which re-hashed every tracked file on every branch switch.
+- `post-rewrite` git hook, so `git pull --rebase` -- which fires neither post-merge nor a branch post-checkout -- no longer leaves tracked files stale
+- `s3lfs status` command: shows which tracked files are modified or missing, the view `git status` cannot give for gitignored files. Supports a path filter, `--all`, and `--porcelain`.
+- `s3lfs merge-driver` and automatic registration by `s3lfs install`: merges concurrent changes to `.s3_manifest.yaml` key-wise and to the `.gitignore` s3lfs block as a set union, so two branches tracking different files no longer conflict. A conflict is still reported when both sides change the same path to different content.
+- `s3lfs clone <url> [dir]` command: clone, install hooks, and download tracked files in one step, since git hooks are never cloned
+- `S3LFS.compare_to_hashes()`: cached disk-state comparison shared by `sync` and `status`
 - `s3lfs verify` command: checks that manifest entries reference content that exists in S3, with `--revision` to verify a committed manifest and `--base` to verify only the entries a push introduces
 - `s3lfs pre-commit` command and pre-commit git hook: uploads modified tracked files and stages the updated manifest at commit time, so every commit's manifest matches the content in S3; blocks the commit if an s3lfs-tracked file is staged for commit in git itself
 - `s3lfs track` now adds tracked paths to a marked block in `.gitignore` and removes already-committed tracked files from the git index, preventing large files from entering git history; `s3lfs remove` removes the `.gitignore` entry
 
 ### Changed
 - The pre-push hook now verifies that pushed manifests reference uploaded content (`s3lfs verify`) instead of uploading at push time. Uploading during pre-push updated only the working-tree manifest, so the commits being pushed still referenced the old hashes; uploads now happen in the pre-commit hook where the manifest change lands in the commit itself.
+
+### Fixed
+- `test_load_cache_stat_oserror` assumed `Path.exists()` is implemented in terms of `Path.stat`, which is no longer true on Python 3.14; the test now patches both explicitly
 
 ## [0.2.0] - 2026-04-11
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,11 @@ A Python-based version control system for large assets using Amazon S3 and S3-co
 - Works with any S3-compatible storage (MinIO, Cloudflare R2, Backblaze B2, Wasabi)
 - **Block-level parallel transfers**: Downloads and uploads flatten all chunks across all files into a single worker pool
 - **Automatic parallel compression**: Uses pigz when available, falls back to gzip
-- **Git hook integration**: `s3lfs install` sets up pre-commit, post-checkout, post-merge, and pre-push hooks
+- **Git hook integration**: `s3lfs install` sets up pre-commit, post-checkout, post-merge, post-rewrite, and pre-push hooks
 - **Accident-proof tracking**: `s3lfs track` gitignores tracked paths and removes them from the git index, so large files can't sneak into git history
+- **Cheap branch switches**: `s3lfs sync` diffs the manifest between revisions and transfers only what changed
+- **Conflict-free manifests**: a git merge driver unions concurrent changes to the manifest and `.gitignore`
+- **One-command setup**: `s3lfs clone` clones, installs hooks, and downloads tracked files
 - **Git LFS migration**: One-command migration with `s3lfs migrate-from-lfs`
 - **GitHub Action**: Built-in CI/CD support with selective checkout
 - **Per-repo config**: `.s3lfsconfig` file for team-wide defaults
@@ -172,17 +175,54 @@ s3lfs verify --revision HEAD --base origin/main
 - `--base REV`: Only verify entries added or changed relative to this revision's manifest (used by the pre-push hook to check just the entries the push introduces)
 - `--no-sign-request`, `--endpoint-url`, `--workers`: As in other commands
 
+### Show Status of Tracked Files
+```sh
+s3lfs status
+s3lfs status data/
+s3lfs status --porcelain
+```
+**Description**: Shows which tracked files are modified or missing. Tracked files are gitignored, so `git status` can't see them -- this is the equivalent view for s3lfs content. Uses the hash cache, so repeat runs are cheap.
+
+**Options**:
+- `--all`: Also list up-to-date files
+- `--porcelain`: One `<code> <path>` line per file for scripting (`M` modified, `D` missing from disk)
+
+### Sync Tracked Files
+```sh
+s3lfs sync
+s3lfs sync --from HEAD~1
+```
+**Description**: Brings tracked files in line with the current manifest. With `--from`, only entries that differ from that revision's manifest are considered, which is what makes branch switches cheap: `checkout --all` re-hashes every tracked file, while a diff touches only what actually changed. Files that the manifest no longer lists are deleted, mirroring what git does for files absent from the branch you switch to -- but only when their content still matches what the old manifest recorded, so local modifications are never destroyed. This is what the post-checkout, post-merge, and post-rewrite hooks run.
+
+**Options**:
+- `--from REV`: Diff against this revision's manifest (without it, checks every tracked file)
+- `--no-prune`: Keep files the manifest no longer lists
+- `--verbose`, `--no-sign-request`, `--endpoint-url`, `--workers`: As in other commands
+
+### Clone a Repository
+```sh
+s3lfs clone <url> [directory]
+```
+**Description**: Clones a repository, installs the s3lfs hooks, and downloads all tracked files. Git hooks live in `.git` and are never cloned, so a fresh clone otherwise has no s3lfs integration until someone remembers to run `s3lfs install`.
+
+**Options**:
+- `--no-checkout`: Install hooks but skip downloading tracked files
+- `--no-sign-request`, `--endpoint-url`, `--workers`: As in other commands
+
 ### Install Git Hooks
 ```sh
 s3lfs install
 ```
-**Description**: Installs git hooks for transparent s3lfs integration. After installation, modified tracked files are automatically uploaded and the manifest staged when you `git commit`, tracked files are automatically downloaded after `git checkout` and `git merge`, and `git push` verifies that every pushed manifest references content that actually exists in S3.
+**Description**: Installs git hooks and the manifest merge driver for transparent s3lfs integration. After installation, modified tracked files are automatically uploaded and the manifest staged when you `git commit`, tracked files are automatically synced after `git checkout`, `git merge`, and `git pull --rebase`, and `git push` verifies that every pushed manifest references content that actually exists in S3.
 
 **Installed hooks**:
 - `pre-commit`: Uploads modified tracked files and stages the updated manifest, so each commit's manifest matches the content in S3. Also blocks the commit if an s3lfs-tracked file is staged for commit in git itself.
-- `post-checkout`: Downloads tracked files after branch checkouts
-- `post-merge`: Downloads tracked files after merges
+- `post-checkout`: Syncs tracked files after branch checkouts, using the previous HEAD's manifest as the diff baseline
+- `post-merge`: Syncs tracked files after merges
+- `post-rewrite`: Syncs tracked files after a rebase, so `git pull --rebase` doesn't leave them stale
 - `pre-push`: Verifies the manifests being pushed reference uploaded content (runs `s3lfs verify` for each pushed ref); aborts the push if content is missing
+
+**Merge driver**: `install` also registers a merge driver for `.s3_manifest.yaml` and `.gitignore`. Two branches that each track different files both rewrite those files, which git's line-based merge calls a conflict even though the change is a clean union. The driver merges the manifest key-wise and the s3lfs `.gitignore` block as a set union, and only reports a conflict when both sides really changed the same path to different content. The `.gitattributes` entry is committed so teammates inherit the rule; the driver itself is local config, and git falls back to its normal merge for anyone who hasn't run `s3lfs install`.
 
 The post-* hooks are non-blocking -- if s3lfs fails or is not available, the git operation continues with a warning. The pre-commit and pre-push hooks abort their git operation on failure (bypass with `--no-verify`), because committing or pushing a manifest whose hashes have no objects behind them breaks every collaborator's checkout. Hooks are appended to existing hook files, preserving any other hooks you have.
 
@@ -190,7 +230,7 @@ The post-* hooks are non-blocking -- if s3lfs fails or is not available, the git
 ```sh
 s3lfs uninstall
 ```
-**Description**: Removes s3lfs git hooks. Other hooks in the same files are preserved.
+**Description**: Removes s3lfs git hooks and the merge driver registration. Other hooks in the same files, and other entries in `.gitattributes`, are preserved.
 
 ### Migrate from Git LFS
 ```sh
@@ -236,8 +276,9 @@ git commit -m "Initialize S3LFS"
 For a Git LFS-like experience where files sync automatically:
 ```sh
 s3lfs install
+git add .gitattributes && git commit -m "Add s3lfs merge driver"
 ```
-With hooks installed, `git commit` automatically uploads modified tracked files and stages the manifest, `git pull` and `git checkout` automatically download tracked files, and `git push` verifies the pushed manifests reference uploaded content.
+With hooks installed, `git commit` automatically uploads modified tracked files and stages the manifest, `git pull`/`git checkout`/`git pull --rebase` automatically sync tracked files, and `git push` verifies the pushed manifests reference uploaded content. The committed `.gitattributes` gives teammates the manifest merge driver once they run `s3lfs install` themselves.
 
 ### 2. Track Large Files
 Instead of committing large files directly to Git, track them with S3LFS:
@@ -258,25 +299,35 @@ git push
 With hooks installed, the pre-commit hook re-uploads any modified tracked files and stages the manifest for you, so `git commit` is enough for day-to-day changes.
 
 ### 4. Clone and Restore Files
-When cloning the repository, restore tracked files:
+Clone, install hooks, and download tracked files in one command:
+```sh
+s3lfs clone https://github.com/your-repo/my-repo.git
+cd my-repo
+```
+
+Or, if you cloned with plain git:
 ```sh
 git clone https://github.com/your-repo/my-repo.git
 cd my-repo
+s3lfs install          # hooks aren't cloned; set them up once per clone
 s3lfs checkout --all
 ```
 
 ### 5. Update Workflow
-For ongoing development:
+For ongoing development with hooks installed, plain git commands are enough -- `git commit` uploads and stages, `git checkout`/`git pull` sync tracked files. To see or drive it by hand:
 ```sh
-# Track any modified large files
+# What changed among tracked files? (git status can't see them)
+s3lfs status
+
+# Upload any modified large files
 s3lfs track --modified
 
 # Commit manifest changes
 git add .s3_manifest.yaml
 git commit -m "Update tracked files"
 
-# Download latest files
-s3lfs checkout --all
+# Bring tracked files in line with the manifest
+s3lfs sync
 ```
 
 ### 6. Selective Downloads

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -1,5 +1,7 @@
 import json
+import os
 import subprocess
+import tempfile
 from pathlib import Path
 
 import click
@@ -292,6 +294,136 @@ def checkout(
         raise click.Abort()
 
 
+def _prune_empty_parents(git_root, path):
+    """Remove directories left empty by a deleted file, up to the git root."""
+    parent = path.parent
+    while parent != git_root and git_root in parent.parents:
+        try:
+            parent.rmdir()
+        except OSError:
+            return
+        parent = parent.parent
+
+
+@cli.command()
+@click.option(
+    "--from",
+    "from_revision",
+    default=None,
+    help="Git revision whose manifest to diff against (default: full checkout)",
+)
+@click.option(
+    "--prune/--no-prune",
+    default=True,
+    help="Delete tracked files that the current manifest no longer lists",
+)
+@click.option("--no-sign-request", is_flag=True, help="Use unsigned S3 requests")
+@click.option(
+    "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
+)
+@click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+@click.option("--verbose", is_flag=True, help="Show detailed progress information")
+@click.option(
+    "--workers",
+    type=int,
+    default=None,
+    help="Number of parallel workers (default: auto-detected from CPU count)",
+)
+def sync(
+    from_revision,
+    prune,
+    no_sign_request,
+    use_acceleration,
+    endpoint_url,
+    verbose,
+    workers,
+):
+    """Bring tracked files in line with the current manifest.
+
+    With --from, only the entries that differ from that revision's manifest
+    are considered, which is what makes branch switches cheap: `checkout
+    --all` re-hashes every tracked file, while a diff touches only what
+    actually changed. Used by the post-checkout, post-merge, and
+    post-rewrite hooks.
+    """
+    git_root, manifest_path, path_resolver = _setup_s3lfs_command()
+
+    s3lfs = _make_s3lfs(
+        git_root,
+        manifest_path,
+        no_sign_request=no_sign_request,
+        use_acceleration=use_acceleration,
+        endpoint_url=endpoint_url,
+        workers=workers,
+    )
+
+    current = dict(s3lfs.manifest.get("files", {}))
+    previous = (
+        _manifest_files_at_revision(git_root, from_revision) if from_revision else None
+    )
+
+    if previous is None:
+        # No baseline to diff against (no --from, an unavailable revision, or
+        # a revision predating s3lfs). Fall back to checking everything.
+        if from_revision:
+            click.echo(
+                f"No manifest available at {from_revision}; "
+                "falling back to a full checkout."
+            )
+        s3lfs.parallel_download_all(silence=not verbose)
+        return
+
+    changed = {k: h for k, h in current.items() if previous.get(k) != h}
+    dropped = {k: h for k, h in previous.items() if k not in current}
+
+    if not changed and not dropped:
+        click.echo("Tracked files are already in sync.")
+        return
+
+    if changed:
+        # The diff says which entries could differ on disk; the disk says
+        # which actually do (a file may already hold the target content).
+        states = s3lfs.compare_to_hashes(changed, progress=verbose)
+        to_download = [
+            (key, changed[key])
+            for key, state in states.items()
+            if state != "up_to_date"
+        ]
+        if to_download:
+            click.echo(f"Downloading {len(to_download)} changed file(s)...")
+            s3lfs.parallel_download_chunked(to_download, silence=not verbose)
+        else:
+            click.echo(f"{len(changed)} changed entr(y/ies) already up-to-date.")
+
+    if dropped and prune:
+        # Only remove content that still matches what the old manifest
+        # recorded. Anything else is local work the user has not tracked,
+        # and deleting it would destroy the only copy.
+        states = s3lfs.compare_to_hashes(dropped, progress=verbose)
+        removed = 0
+        for key, state in sorted(states.items()):
+            if state == "missing":
+                continue
+            if state == "modified":
+                click.echo(
+                    f"Keeping {key}: it is no longer tracked but has local "
+                    "modifications."
+                )
+                continue
+            filesystem_path = path_resolver.to_filesystem_path(key)
+            filesystem_path.unlink()
+            _prune_empty_parents(git_root, filesystem_path)
+            removed += 1
+            if verbose:
+                click.echo(f"  Removed {key}")
+        if removed:
+            click.echo(f"Removed {removed} file(s) no longer tracked.")
+
+
 @cli.command()
 @click.argument("path", required=False)
 @click.option("--no-sign-request", is_flag=True, help="Use unsigned S3 requests")
@@ -375,6 +507,114 @@ def ls(
             verbose=verbose,
             strip_prefix=str(relative_cwd) if relative_cwd != Path(".") else None,
         )
+
+
+@cli.command()
+@click.argument("path", required=False)
+@click.option(
+    "--all",
+    "show_all",
+    is_flag=True,
+    help="Include up-to-date files in the listing",
+)
+@click.option(
+    "--porcelain",
+    is_flag=True,
+    help="Machine-readable output: one '<code> <path>' line per file",
+)
+@click.option("--no-sign-request", is_flag=True, help="Use unsigned S3 requests")
+@click.option(
+    "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
+)
+@click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+def status(path, show_all, porcelain, no_sign_request, use_acceleration, endpoint_url):
+    """Show which tracked files are modified or missing.
+
+    Tracked files are gitignored, so `git status` cannot see them. This is
+    the equivalent view for s3lfs-tracked content.
+    """
+    if path:
+        git_root, manifest_path, path_resolver, manifest_key = _setup_s3lfs_command(
+            cli_path=path
+        )
+    else:
+        git_root, manifest_path, path_resolver = _setup_s3lfs_command()
+        manifest_key = None
+
+    s3lfs = _make_s3lfs(
+        git_root,
+        manifest_path,
+        no_sign_request=no_sign_request,
+        use_acceleration=use_acceleration,
+        endpoint_url=endpoint_url,
+    )
+
+    if manifest_key:
+        expected = s3lfs._resolve_manifest_paths(manifest_key)
+    else:
+        expected = dict(s3lfs.manifest.get("files", {}))
+
+    if not expected:
+        if not porcelain:
+            click.echo("No files are tracked by s3lfs.")
+        return
+
+    states = s3lfs.compare_to_hashes(expected)
+
+    # Show paths relative to where the user is standing, as ls does.
+    try:
+        relative_cwd = Path.cwd().relative_to(git_root)
+    except ValueError:
+        relative_cwd = Path(".")
+
+    def display(key):
+        if relative_cwd == Path("."):
+            return key
+        try:
+            return str(Path(key).relative_to(relative_cwd).as_posix())
+        except ValueError:
+            return key
+
+    modified = sorted(k for k, v in states.items() if v == "modified")
+    missing = sorted(k for k, v in states.items() if v == "missing")
+    up_to_date = sorted(k for k, v in states.items() if v == "up_to_date")
+
+    if porcelain:
+        for key in modified:
+            click.echo(f"M {display(key)}")
+        for key in missing:
+            click.echo(f"D {display(key)}")
+        if show_all:
+            for key in up_to_date:
+                click.echo(f"  {display(key)}")
+        return
+
+    click.echo(
+        f"{len(states)} tracked file(s): {len(up_to_date)} up-to-date, "
+        f"{len(modified)} modified, {len(missing)} missing"
+    )
+
+    if modified:
+        click.echo()
+        click.echo("Modified (upload with 's3lfs track --modified'):")
+        for key in modified:
+            click.echo(f"  {display(key)}")
+
+    if missing:
+        click.echo()
+        click.echo("Missing from disk (download with 's3lfs checkout --all'):")
+        for key in missing:
+            click.echo(f"  {display(key)}")
+
+    if show_all and up_to_date:
+        click.echo()
+        click.echo("Up-to-date:")
+        for key in up_to_date:
+            click.echo(f"  {display(key)}")
 
 
 @click.command()
@@ -780,21 +1020,17 @@ S3LFS_GITIGNORE_START = "# >>> s3lfs tracked files >>>"
 S3LFS_GITIGNORE_END = "# <<< s3lfs tracked files <<<"
 
 
-def _load_gitignore_block(git_root):
-    """Split .gitignore into (lines_before, block_entries, lines_after).
+S3LFS_GITATTRIBUTES_START = "# >>> s3lfs manifest merge >>>"
+S3LFS_GITATTRIBUTES_END = "# <<< s3lfs manifest merge <<<"
 
-    The s3lfs block is delimited by marker comments so entries can be
-    added and removed without disturbing the rest of the file.
-    """
-    gitignore = git_root / ".gitignore"
-    if not gitignore.exists():
-        return [], [], []
-    lines = gitignore.read_text().splitlines()
-    if S3LFS_GITIGNORE_START not in lines:
+
+def _split_marked_lines(lines, start_marker, end_marker):
+    """Split lines into (before, block_entries, after)."""
+    if start_marker not in lines:
         return lines, [], []
-    start = lines.index(S3LFS_GITIGNORE_START)
+    start = lines.index(start_marker)
     try:
-        end = lines.index(S3LFS_GITIGNORE_END, start)
+        end = lines.index(end_marker, start)
     except ValueError:
         # Malformed block (no end marker): drop only the start marker and
         # keep everything else out of the block rather than swallowing
@@ -804,40 +1040,74 @@ def _load_gitignore_block(git_root):
     return lines[:start], entries, lines[end + 1 :]
 
 
-def _save_gitignore_block(git_root, before, entries, after):
-    """Write .gitignore back with the s3lfs block holding these entries."""
-    gitignore = git_root / ".gitignore"
+def _load_marked_block(path, start_marker, end_marker):
+    """Split a line-oriented file into (before, block_entries, after).
+
+    The s3lfs block is delimited by marker comments so entries can be
+    added and removed without disturbing the rest of the file.
+    """
+    if not path.exists():
+        return [], [], []
+    return _split_marked_lines(path.read_text().splitlines(), start_marker, end_marker)
+
+
+def _save_marked_block(path, start_marker, end_marker, before, entries, after):
+    """Write the file back with the s3lfs block holding these entries."""
     lines = list(before)
     if entries:
         if lines and lines[-1].strip():
             lines.append("")
-        lines.append(S3LFS_GITIGNORE_START)
+        lines.append(start_marker)
         lines.extend(entries)
-        lines.append(S3LFS_GITIGNORE_END)
+        lines.append(end_marker)
     lines.extend(after)
-    if not lines and not gitignore.exists():
+    if not lines and not path.exists():
         return
-    gitignore.write_text("\n".join(lines) + ("\n" if lines else ""))
+    path.write_text("\n".join(lines) + ("\n" if lines else ""))
+
+
+def _add_marked_entry(path, start_marker, end_marker, entry):
+    """Add an entry to a marked block. Returns True if it was added."""
+    before, entries, after = _load_marked_block(path, start_marker, end_marker)
+    if entry in entries:
+        return False
+    entries.append(entry)
+    _save_marked_block(path, start_marker, end_marker, before, entries, after)
+    return True
+
+
+def _remove_marked_entries(path, start_marker, end_marker, entry_variants):
+    """Remove any of these entries from a marked block. True if any went."""
+    before, entries, after = _load_marked_block(path, start_marker, end_marker)
+    kept = [e for e in entries if e not in entry_variants]
+    if kept == entries:
+        return False
+    _save_marked_block(path, start_marker, end_marker, before, kept, after)
+    return True
+
+
+def _load_gitignore_block(git_root):
+    """Split .gitignore into (lines_before, s3lfs entries, lines_after)."""
+    return _load_marked_block(
+        git_root / ".gitignore", S3LFS_GITIGNORE_START, S3LFS_GITIGNORE_END
+    )
 
 
 def _add_gitignore_entry(git_root, entry):
     """Add an entry to the s3lfs block in .gitignore. Returns True if added."""
-    before, entries, after = _load_gitignore_block(git_root)
-    if entry in entries:
-        return False
-    entries.append(entry)
-    _save_gitignore_block(git_root, before, entries, after)
-    return True
+    return _add_marked_entry(
+        git_root / ".gitignore", S3LFS_GITIGNORE_START, S3LFS_GITIGNORE_END, entry
+    )
 
 
 def _remove_gitignore_entry(git_root, entry_variants):
-    """Remove any of these entries from the s3lfs block. Returns True if removed."""
-    before, entries, after = _load_gitignore_block(git_root)
-    kept = [e for e in entries if e not in entry_variants]
-    if kept == entries:
-        return False
-    _save_gitignore_block(git_root, before, kept, after)
-    return True
+    """Remove any of these entries from the s3lfs block. True if removed."""
+    return _remove_marked_entries(
+        git_root / ".gitignore",
+        S3LFS_GITIGNORE_START,
+        S3LFS_GITIGNORE_END,
+        entry_variants,
+    )
 
 
 def _gitignore_entry_for(git_root, manifest_key):
@@ -955,20 +1225,42 @@ S3LFS_HOOK_START = "# >>> s3lfs hook >>>"
 S3LFS_HOOK_END = "# <<< s3lfs hook <<<"
 
 _POST_MERGE_BODY = """\
-# Auto-checkout s3lfs files after merge
+# Sync s3lfs files after merge.
+#
+# ORIG_HEAD is the pre-merge commit, so the manifest diff against it covers
+# exactly what the merge brought in. s3lfs sync falls back to a full
+# checkout if that revision is unavailable.
 if command -v s3lfs >/dev/null 2>&1; then
-    if ! s3lfs checkout --all 2>&1; then
-        echo "s3lfs: ERROR: post-merge checkout failed" >&2
+    if ! s3lfs sync --from ORIG_HEAD 2>&1; then
+        echo "s3lfs: ERROR: post-merge sync failed" >&2
         echo "s3lfs: large files may be missing or stale; run 's3lfs checkout --all'" >&2
     fi
 fi"""
 
 _POST_CHECKOUT_BODY = """\
-# Auto-checkout s3lfs files after checkout
-# Only run on branch checkouts ($3 == 1), not file checkouts
+# Sync s3lfs files after checkout.
+#
+# Only run on branch checkouts ($3 == 1), not file checkouts. $1 is the
+# previous HEAD, so diffing its manifest against the new one downloads only
+# what this branch switch actually changed instead of re-hashing every
+# tracked file.
 if [ "$3" = "1" ] && command -v s3lfs >/dev/null 2>&1; then
-    if ! s3lfs checkout --all 2>&1; then
-        echo "s3lfs: ERROR: post-checkout checkout failed" >&2
+    if ! s3lfs sync --from "$1" 2>&1; then
+        echo "s3lfs: ERROR: post-checkout sync failed" >&2
+        echo "s3lfs: large files may be missing or stale; run 's3lfs checkout --all'" >&2
+    fi
+fi"""
+
+_POST_REWRITE_BODY = """\
+# Sync s3lfs files after a rebase.
+#
+# `git pull --rebase` fires neither post-merge nor a branch post-checkout,
+# so without this hook the most common pull configuration leaves tracked
+# files stale. Amends ($1 = amend) rarely touch the manifest and leave
+# ORIG_HEAD stale, so they are skipped.
+if [ "$1" = "rebase" ] && command -v s3lfs >/dev/null 2>&1; then
+    if ! s3lfs sync --from ORIG_HEAD 2>&1; then
+        echo "s3lfs: ERROR: post-rewrite sync failed" >&2
         echo "s3lfs: large files may be missing or stale; run 's3lfs checkout --all'" >&2
     fi
 fi"""
@@ -1018,6 +1310,9 @@ HOOK_SCRIPTS = {
     "post-merge": S3LFS_HOOK_START + "\n" + _POST_MERGE_BODY + "\n" + S3LFS_HOOK_END,
     "post-checkout": (
         S3LFS_HOOK_START + "\n" + _POST_CHECKOUT_BODY + "\n" + S3LFS_HOOK_END
+    ),
+    "post-rewrite": (
+        S3LFS_HOOK_START + "\n" + _POST_REWRITE_BODY + "\n" + S3LFS_HOOK_END
     ),
     "pre-commit": S3LFS_HOOK_START + "\n" + _PRE_COMMIT_BODY + "\n" + S3LFS_HOOK_END,
     "pre-push": S3LFS_HOOK_START + "\n" + _PRE_PUSH_BODY + "\n" + S3LFS_HOOK_END,
@@ -1136,6 +1431,9 @@ def install():
         hook_path = _install_hook(hooks_dir, hook_name, hook_block)
         click.echo(f"  Installed {hook_name} hook -> {hook_path}")
 
+    _install_merge_driver(git_root)
+    click.echo("  Registered manifest merge driver (.gitattributes, git config)")
+
     click.echo()
     click.echo("s3lfs hooks installed. Your git workflow now automatically:")
     click.echo(
@@ -1143,11 +1441,97 @@ def install():
     )
     click.echo("  - Blocks committing s3lfs-tracked files into git (pre-commit)")
     click.echo(
-        "  - Downloads tracked files after checkout/merge (post-checkout, post-merge)"
+        "  - Syncs tracked files after checkout/merge/rebase "
+        "(post-checkout, post-merge, post-rewrite)"
     )
     click.echo("  - Verifies pushed manifests reference uploaded content (pre-push)")
+    click.echo("  - Merges concurrent manifest changes without conflicts")
     click.echo()
+    click.echo("Commit the updated .gitattributes so teammates inherit the merge rule.")
     click.echo("Run 's3lfs uninstall' to remove hooks.")
+
+
+@click.command()
+@click.argument("url", required=True)
+@click.argument("directory", required=False)
+@click.option(
+    "--no-checkout",
+    is_flag=True,
+    help="Install hooks but don't download tracked files",
+)
+@click.option("--no-sign-request", is_flag=True, help="Use unsigned S3 requests")
+@click.option(
+    "--use-acceleration", is_flag=True, help="Enable S3 Transfer Acceleration"
+)
+@click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+@click.option(
+    "--workers",
+    type=int,
+    default=None,
+    help="Number of parallel workers (default: auto-detected from CPU count)",
+)
+@click.pass_context
+def clone(
+    ctx,
+    url,
+    directory,
+    no_checkout,
+    no_sign_request,
+    use_acceleration,
+    endpoint_url,
+    workers,
+):
+    """Clone a repository, install s3lfs hooks, and download tracked files.
+
+    Hooks live in .git and are never cloned, so a fresh clone has no s3lfs
+    integration until someone runs 's3lfs install'. This does the whole
+    day-one setup in one command.
+    """
+    target = directory or Path(url.rstrip("/")).name
+    if target.endswith(".git"):
+        target = target[: -len(".git")]
+
+    result = subprocess.run(["git", "clone", url] + ([directory] if directory else []))
+    if result.returncode != 0:
+        raise SystemExit(result.returncode)
+
+    target_path = Path(target).resolve()
+    if not target_path.is_dir():
+        click.echo(f"Error: expected clone at {target_path}, but it is not there")
+        raise SystemExit(1)
+
+    original_cwd = Path.cwd()
+    os.chdir(target_path)
+    try:
+        if not get_manifest_path(target_path).exists():
+            click.echo()
+            click.echo(
+                "Cloned, but this repository is not s3lfs-initialized "
+                "(no manifest). Nothing else to do."
+            )
+            return
+
+        click.echo()
+        ctx.invoke(install)
+
+        if no_checkout:
+            return
+
+        click.echo()
+        ctx.invoke(
+            checkout,
+            all=True,
+            no_sign_request=no_sign_request,
+            use_acceleration=use_acceleration,
+            endpoint_url=endpoint_url,
+            workers=workers,
+        )
+    finally:
+        os.chdir(original_cwd)
 
 
 @click.command()
@@ -1165,11 +1549,239 @@ def uninstall():
             click.echo(f"  Removed {hook_name} hook")
             removed = True
 
+    if _uninstall_merge_driver(git_root):
+        click.echo("  Removed manifest merge driver registration")
+        removed = True
+
     if removed:
         click.echo()
         click.echo("s3lfs hooks removed.")
     else:
         click.echo("No s3lfs hooks found.")
+
+
+MERGE_DRIVER_COMMAND = "s3lfs merge-driver %O %A %B %P"
+MANIFEST_NAMES = (".s3_manifest.yaml", ".s3_manifest.json")
+# Both files are rewritten by every `s3lfs track`, so both conflict when
+# two branches track different files.
+MERGE_DRIVER_PATHS = MANIFEST_NAMES + (".gitignore",)
+
+
+def _merge_maps(base, ours, theirs):
+    """Three-way merge of two flat maps. Returns (merged, conflicting_keys).
+
+    A key only conflicts when both sides changed it away from the base to
+    different values; a change on one side alone (including a deletion)
+    is taken as-is.
+    """
+    merged = {}
+    conflicts = []
+    for key in set(base) | set(ours) | set(theirs):
+        o, a, b = base.get(key), ours.get(key), theirs.get(key)
+        if a == b:
+            value = a
+        elif a == o:
+            value = b
+        elif b == o:
+            value = a
+        else:
+            conflicts.append(key)
+            value = a
+        if value is not None:
+            merged[key] = value
+    return merged, sorted(conflicts)
+
+
+def _read_manifest_for_merge(path):
+    """Load one side of a manifest merge. Missing or empty reads as empty."""
+    path = Path(path)
+    if not path.exists():
+        return {}
+    # safe_load parses both the YAML and JSON manifest formats
+    data = yaml.safe_load(path.read_text()) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} is not a manifest mapping")
+    return data
+
+
+def _merge_ordered_entries(base, ours, theirs):
+    """Three-way merge of an ordered list of unique lines.
+
+    An entry present in the base survives unless a side deleted it;
+    entries either side added are appended. Order is stable so the block
+    does not churn between merges.
+    """
+    merged = [e for e in base if e in ours and e in theirs]
+    for side in (ours, theirs):
+        for entry in side:
+            if entry not in base and entry not in merged:
+                merged.append(entry)
+    return merged
+
+
+def _merge_gitignore(base, ours, theirs):
+    """Merge .gitignore, unioning the s3lfs block. Returns (text, conflict).
+
+    Two branches that track different files both append to the s3lfs
+    block, which git's line-based merge calls a conflict. The block
+    merges as a set union; the rest of the file is handed to git's own
+    text merge so the user's entries behave exactly as they normally do.
+    """
+    sides = {}
+    for name, path in (("base", base), ("ours", ours), ("theirs", theirs)):
+        path = Path(path)
+        text = path.read_text() if path.exists() else ""
+        before, entries, after = _split_marked_lines(
+            text.splitlines(), S3LFS_GITIGNORE_START, S3LFS_GITIGNORE_END
+        )
+        # The block is always written at the end, so the user's content is
+        # just everything outside it.
+        sides[name] = (before + after, entries)
+
+    entries = _merge_ordered_entries(
+        sides["base"][1], sides["ours"][1], sides["theirs"][1]
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        paths = {}
+        for name, (rest, _) in sides.items():
+            side_path = Path(tmp) / name
+            side_path.write_text("\n".join(rest) + ("\n" if rest else ""))
+            paths[name] = str(side_path)
+        result = subprocess.run(
+            ["git", "merge-file", "-p", paths["ours"], paths["base"], paths["theirs"]],
+            capture_output=True,
+            text=True,
+        )
+        # git merge-file returns the number of conflicts, or <0 on error.
+        conflict = result.returncode != 0
+        merged_rest = result.stdout.splitlines()
+
+    lines = list(merged_rest)
+    if entries:
+        if lines and lines[-1].strip():
+            lines.append("")
+        lines.append(S3LFS_GITIGNORE_START)
+        lines.extend(entries)
+        lines.append(S3LFS_GITIGNORE_END)
+    return "\n".join(lines) + ("\n" if lines else ""), conflict
+
+
+@click.command("merge-driver")
+@click.argument("base", type=click.Path())
+@click.argument("ours", type=click.Path())
+@click.argument("theirs", type=click.Path())
+@click.argument("target", type=click.Path(), required=False)
+def merge_driver(base, ours, theirs, target):
+    """Three-way merge s3lfs-managed files (git merge driver).
+
+    Registered by 's3lfs install' for the manifest and .gitignore. Two
+    branches that each track different files rewrite both, which git's
+    line-based merge reports as a conflict even though the change is a
+    clean union. This merges the manifest key-wise and the .gitignore
+    block as a set union, so a conflict is only reported when both sides
+    really disagree about the same path.
+
+    Writes the result over OURS, as git requires, and exits non-zero when
+    a real conflict remains.
+    """
+    if target and Path(target).name == ".gitignore":
+        merged_text, conflict = _merge_gitignore(base, ours, theirs)
+        Path(ours).write_text(merged_text)
+        if conflict:
+            click.echo(
+                "s3lfs: .gitignore has conflicting non-s3lfs edits; "
+                "resolve them and 'git add' the file.",
+                err=True,
+            )
+            raise SystemExit(1)
+        return
+
+    try:
+        base_data = _read_manifest_for_merge(base)
+        our_data = _read_manifest_for_merge(ours)
+        their_data = _read_manifest_for_merge(theirs)
+    except Exception as e:
+        click.echo(f"s3lfs: cannot merge manifest ({e}); falling back to git", err=True)
+        raise SystemExit(1)
+
+    files, file_conflicts = _merge_maps(
+        base_data.get("files") or {},
+        our_data.get("files") or {},
+        their_data.get("files") or {},
+    )
+    meta, meta_conflicts = _merge_maps(
+        {k: v for k, v in base_data.items() if k != "files"},
+        {k: v for k, v in our_data.items() if k != "files"},
+        {k: v for k, v in their_data.items() if k != "files"},
+    )
+    merged = dict(meta)
+    merged["files"] = files
+
+    # %A is a temp file, so the real path (%P) is what says which format to
+    # write back; without it, fall back to what our side looks like.
+    name = target or ours
+    as_json = str(name).endswith(".json") or Path(ours).read_text().lstrip().startswith(
+        "{"
+    )
+    with open(ours, "w") as f:
+        if as_json:
+            json.dump(merged, f, indent=4, sort_keys=True)
+        else:
+            yaml.safe_dump(merged, f, default_flow_style=False, sort_keys=True)
+
+    conflicts = file_conflicts + meta_conflicts
+    if conflicts:
+        click.echo(
+            "s3lfs: manifest conflict -- both sides changed these entries:", err=True
+        )
+        for key in conflicts:
+            click.echo(f"  {key}", err=True)
+        click.echo(
+            "s3lfs: our version was kept for each; edit the manifest and "
+            "'git add' it to resolve.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+
+def _install_merge_driver(git_root):
+    """Register the manifest merge driver for this repository."""
+    subprocess.run(
+        ["git", "config", "merge.s3lfs.name", "s3lfs manifest merge"],
+        cwd=str(git_root),
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "merge.s3lfs.driver", MERGE_DRIVER_COMMAND],
+        cwd=str(git_root),
+        capture_output=True,
+    )
+    # The .gitattributes entry is committed so teammates inherit it; the
+    # driver itself is local config, and git falls back to its normal merge
+    # for anyone who has not run 's3lfs install'.
+    for name in MERGE_DRIVER_PATHS:
+        _add_marked_entry(
+            git_root / ".gitattributes",
+            S3LFS_GITATTRIBUTES_START,
+            S3LFS_GITATTRIBUTES_END,
+            f"{name} merge=s3lfs",
+        )
+
+
+def _uninstall_merge_driver(git_root):
+    """Remove the manifest merge driver registration. True if anything went."""
+    subprocess.run(
+        ["git", "config", "--remove-section", "merge.s3lfs"],
+        cwd=str(git_root),
+        capture_output=True,
+    )
+    return _remove_marked_entries(
+        git_root / ".gitattributes",
+        S3LFS_GITATTRIBUTES_START,
+        S3LFS_GITATTRIBUTES_END,
+        {f"{name} merge=s3lfs" for name in MERGE_DRIVER_PATHS},
+    )
 
 
 @click.command()
@@ -1314,6 +1926,8 @@ cli.add_command(install)
 cli.add_command(uninstall)
 cli.add_command(verify)
 cli.add_command(pre_commit)
+cli.add_command(merge_driver)
+cli.add_command(clone)
 
 
 def main():

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -1001,6 +1001,68 @@ class S3LFS:
             return cached_data["hash"]
         return None
 
+    def compare_to_hashes(self, expected, progress=False):
+        """Compare files on disk against the hashes they are expected to have.
+
+        :param expected: dict of manifest_key -> expected hash
+        :param progress: show a progress bar while hashing
+        :return: dict of manifest_key -> "up_to_date" | "modified" | "missing"
+
+        Uses the same load-cache-once, hash-on-miss strategy as
+        track_modified_files_cached, so repeat calls over unchanged files
+        cost a stat() each rather than a full re-read.
+        """
+        if not expected:
+            return {}
+
+        with self._lock_context():
+            self.load_cache()
+
+        states = {}
+        cache_updates = {}
+
+        with tqdm(
+            total=len(expected),
+            desc="Checking files",
+            unit="file",
+            disable=not progress,
+        ) as pbar:
+            for manifest_key, expected_hash in expected.items():
+                pbar.update(1)
+                filesystem_path = self.path_resolver.to_filesystem_path(manifest_key)
+                if not filesystem_path.exists():
+                    states[manifest_key] = "missing"
+                    continue
+
+                stat = filesystem_path.stat()
+                metadata = {
+                    "size": stat.st_size,
+                    "mtime": stat.st_mtime,
+                    "inode": getattr(stat, "st_ino", None),
+                }
+                cache_key = str(Path(manifest_key).as_posix())
+
+                current_hash = self._check_cache_hit(cache_key, metadata)
+                if current_hash is None:
+                    current_hash = self.hash_file(filesystem_path)
+                    cache_updates[cache_key] = {
+                        "hash": current_hash,
+                        "metadata": metadata,
+                        "timestamp": time.time(),
+                    }
+
+                states[manifest_key] = (
+                    "up_to_date" if current_hash == expected_hash else "modified"
+                )
+
+        if cache_updates:
+            with self._lock_context():
+                self.hash_cache.update(cache_updates)
+                self._cache_dirty = True
+                self.save_cache()
+
+        return states
+
     def track_modified_files_cached(self, silence=True):
         """
         Check manifest for outdated hashes using cached hashing and upload

--- a/tests/test_coverage_improvements_core.py
+++ b/tests/test_coverage_improvements_core.py
@@ -103,19 +103,28 @@ class TestCoreCoverageImprovements(unittest.TestCase):
         s3lfs._cache_dirty = True
         s3lfs.save_cache()  # creates the cache file on disk
 
+        # Hold the cache file's existence check True while its stat() fails,
+        # so load_cache reaches the explicit stat() rather than the
+        # file-absent branch. Counting stat() calls instead would depend on
+        # whether Path.exists() is implemented in terms of Path.stat, which
+        # varies by Python version.
         real_stat = Path.stat
-        call_count = {"n": 0}
+        real_exists = Path.exists
 
-        def flaky_stat(self_path, *a, **kw):
+        def failing_stat(self_path, *a, **kw):
             if self_path == s3lfs.cache_file:
-                call_count["n"] += 1
-                # Let exists() (which calls stat() internally) succeed, but
-                # make the explicit stat() call inside load_cache() raise.
-                if call_count["n"] >= 2:
-                    raise OSError("boom")
+                raise OSError("boom")
             return real_stat(self_path, *a, **kw)
 
-        with patch("s3lfs.core.Path.stat", flaky_stat):
+        def always_exists(self_path, *a, **kw):
+            if self_path == s3lfs.cache_file:
+                return True
+            return real_exists(self_path, *a, **kw)
+
+        with (
+            patch("s3lfs.core.Path.stat", failing_stat),
+            patch("s3lfs.core.Path.exists", always_exists),
+        ):
             s3lfs.load_cache(force=True)
         self.assertIsNone(s3lfs._cache_mtime)
 

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -1,14 +1,17 @@
 """Tests for the git-workflow integration: .gitignore protection of tracked
 paths, the pre-commit command, and push-time verification."""
 
+import json
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 
 import boto3
+import yaml
 from click.testing import CliRunner
 from moto import mock_s3
 
@@ -16,7 +19,9 @@ from s3lfs.cli import (
     S3LFS_GITIGNORE_END,
     S3LFS_GITIGNORE_START,
     _add_gitignore_entry,
+    _install_merge_driver,
     _load_gitignore_block,
+    _merge_gitignore,
     _remove_gitignore_entry,
     cli,
 )
@@ -327,6 +332,501 @@ class TestVerifyCommand(GitRepoTestCase):
         result = self.runner.invoke(cli, ["verify", "--revision", "HEAD"])
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertIn("No manifest at revision", result.output)
+
+
+class TestSyncCommand(GitRepoTestCase):
+    """s3lfs sync: manifest-diff-based branch switching."""
+
+    def _track_and_commit(self, rel_path, content, message):
+        self._write(rel_path, content)
+        self.runner.invoke(cli, ["track", rel_path])
+        self._commit_all(message)
+
+    def test_sync_downloads_only_changed_entries(self):
+        """The diff, not the whole manifest, decides what gets downloaded.
+
+        Both files are deleted from disk; syncing from the revision that
+        only lacked the second one must restore that one alone. A full
+        checkout would restore both.
+        """
+        self._track_and_commit("data/a.bin", "a", "track a")
+        self._track_and_commit("data/b.bin", "b", "track b")
+
+        Path("data/a.bin").unlink()
+        Path("data/b.bin").unlink()
+
+        result = self.runner.invoke(cli, ["sync", "--from", "HEAD~1"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        self.assertTrue(Path("data/b.bin").exists(), "changed entry not restored")
+        self.assertFalse(
+            Path("data/a.bin").exists(),
+            "unchanged entry was downloaded; sync did a full checkout",
+        )
+
+    def test_sync_updates_changed_content(self):
+        self._track_and_commit("data/a.bin", "v1", "track v1")
+        self._write("data/a.bin", "v2")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track v2")
+
+        self._write("data/a.bin", "stale")
+        result = self.runner.invoke(cli, ["sync", "--from", "HEAD~1"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(Path("data/a.bin").read_text(), "v2")
+
+    def test_sync_reports_when_already_in_sync(self):
+        self._track_and_commit("data/a.bin", "a", "track a")
+        result = self.runner.invoke(cli, ["sync", "--from", "HEAD"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("already in sync", result.output)
+
+    def test_sync_prunes_untracked_files(self):
+        """A file dropped from the manifest is removed from disk, as git
+        does for files absent from the branch being switched to."""
+        self._track_and_commit("data/a.bin", "a", "track a")
+        self.runner.invoke(cli, ["remove", "data/a.bin"])
+        self._commit_all("untrack a")
+
+        result = self.runner.invoke(cli, ["sync", "--from", "HEAD~1"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertFalse(Path("data/a.bin").exists())
+        self.assertIn("Removed 1 file(s)", result.output)
+
+    def test_sync_prune_removes_emptied_directories(self):
+        self._track_and_commit("data/nested/a.bin", "a", "track a")
+        self.runner.invoke(cli, ["remove", "data/nested/a.bin"])
+        self._commit_all("untrack a")
+
+        self.runner.invoke(cli, ["sync", "--from", "HEAD~1"])
+        self.assertFalse(Path("data/nested").exists())
+
+    def test_sync_keeps_locally_modified_file_when_pruning(self):
+        """Pruning must never destroy content that is not in S3."""
+        self._track_and_commit("data/a.bin", "a", "track a")
+        self.runner.invoke(cli, ["remove", "data/a.bin"])
+        self._commit_all("untrack a")
+        self._write("data/a.bin", "local edits worth keeping")
+
+        result = self.runner.invoke(cli, ["sync", "--from", "HEAD~1"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertTrue(Path("data/a.bin").exists())
+        self.assertEqual(Path("data/a.bin").read_text(), "local edits worth keeping")
+        self.assertIn("local modifications", result.output)
+
+    def test_sync_no_prune_keeps_dropped_files(self):
+        self._track_and_commit("data/a.bin", "a", "track a")
+        self.runner.invoke(cli, ["remove", "data/a.bin"])
+        self._commit_all("untrack a")
+
+        result = self.runner.invoke(cli, ["sync", "--from", "HEAD~1", "--no-prune"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertTrue(Path("data/a.bin").exists())
+
+    def test_sync_falls_back_to_full_checkout_without_baseline(self):
+        """An unknown revision (fresh clone, shallow history) must still
+        produce correct files, just without the diff optimization."""
+        self._track_and_commit("data/a.bin", "a", "track a")
+        Path("data/a.bin").unlink()
+
+        zero = "0" * 40
+        result = self.runner.invoke(cli, ["sync", "--from", zero])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("falling back to a full checkout", result.output)
+        self.assertTrue(Path("data/a.bin").exists())
+
+    def test_sync_without_from_does_full_checkout(self):
+        self._track_and_commit("data/a.bin", "a", "track a")
+        Path("data/a.bin").unlink()
+
+        result = self.runner.invoke(cli, ["sync"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertTrue(Path("data/a.bin").exists())
+
+
+class TestStatusCommand(GitRepoTestCase):
+    """s3lfs status: the view git status cannot give for ignored files."""
+
+    def test_status_reports_up_to_date(self):
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+
+        result = self.runner.invoke(cli, ["status"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("1 up-to-date", result.output)
+
+    def test_status_reports_modified(self):
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._write("data/a.bin", "changed")
+
+        result = self.runner.invoke(cli, ["status"])
+        self.assertIn("1 modified", result.output)
+        self.assertIn("Modified", result.output)
+        self.assertIn("data/a.bin", result.output)
+
+    def test_status_reports_missing(self):
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        Path("data/a.bin").unlink()
+
+        result = self.runner.invoke(cli, ["status"])
+        self.assertIn("1 missing", result.output)
+        self.assertIn("Missing from disk", result.output)
+
+    def test_status_porcelain_codes(self):
+        self._write("data/a.bin", "a")
+        self._write("data/b.bin", "b")
+        self.runner.invoke(cli, ["track", "data"])
+        self._write("data/a.bin", "changed")
+        Path("data/b.bin").unlink()
+
+        result = self.runner.invoke(cli, ["status", "--porcelain"])
+        lines = sorted(result.output.splitlines())
+        self.assertEqual(lines, ["D data/b.bin", "M data/a.bin"])
+
+    def test_status_path_filter(self):
+        self._write("data/a.bin", "a")
+        self._write("other/b.bin", "b")
+        self.runner.invoke(cli, ["track", "data"])
+        self.runner.invoke(cli, ["track", "other"])
+
+        result = self.runner.invoke(cli, ["status", "data", "--porcelain", "--all"])
+        self.assertIn("data/a.bin", result.output)
+        self.assertNotIn("other/b.bin", result.output)
+
+    def test_status_with_nothing_tracked(self):
+        result = self.runner.invoke(cli, ["status"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("No files are tracked", result.output)
+
+
+class TestMergeDriver(unittest.TestCase):
+    """The manifest merge driver: union by key, conflict only on real
+    disagreement about the same path."""
+
+    def setUp(self):
+        self.temp_dir = Path(os.path.realpath(tempfile.mkdtemp()))
+        self.runner = CliRunner()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _manifest(self, name, files, **extra):
+        import yaml as _yaml
+
+        path = self.temp_dir / name
+        data = {"bucket_name": "b", "repo_prefix": "p", "files": files}
+        data.update(extra)
+        path.write_text(_yaml.safe_dump(data))
+        return path
+
+    def _merged_files(self):
+        import yaml as _yaml
+
+        return _yaml.safe_load((self.temp_dir / "ours.yaml").read_text())["files"]
+
+    def test_disjoint_additions_merge_cleanly(self):
+        base = self._manifest("base.yaml", {"shared.bin": "h0"})
+        ours = self._manifest("ours.yaml", {"shared.bin": "h0", "a.bin": "ha"})
+        theirs = self._manifest("theirs.yaml", {"shared.bin": "h0", "b.bin": "hb"})
+
+        result = self.runner.invoke(
+            cli, ["merge-driver", str(base), str(ours), str(theirs)]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(
+            self._merged_files(),
+            {"shared.bin": "h0", "a.bin": "ha", "b.bin": "hb"},
+        )
+
+    def test_identical_change_on_both_sides_is_not_a_conflict(self):
+        base = self._manifest("base.yaml", {"a.bin": "h0"})
+        ours = self._manifest("ours.yaml", {"a.bin": "h1"})
+        theirs = self._manifest("theirs.yaml", {"a.bin": "h1"})
+
+        result = self.runner.invoke(
+            cli, ["merge-driver", str(base), str(ours), str(theirs)]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(self._merged_files(), {"a.bin": "h1"})
+
+    def test_one_sided_change_is_taken(self):
+        base = self._manifest("base.yaml", {"a.bin": "h0"})
+        ours = self._manifest("ours.yaml", {"a.bin": "h0"})
+        theirs = self._manifest("theirs.yaml", {"a.bin": "h2"})
+
+        result = self.runner.invoke(
+            cli, ["merge-driver", str(base), str(ours), str(theirs)]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(self._merged_files(), {"a.bin": "h2"})
+
+    def test_one_sided_deletion_is_taken(self):
+        base = self._manifest("base.yaml", {"a.bin": "h0", "b.bin": "hb"})
+        ours = self._manifest("ours.yaml", {"a.bin": "h0", "b.bin": "hb"})
+        theirs = self._manifest("theirs.yaml", {"b.bin": "hb"})
+
+        result = self.runner.invoke(
+            cli, ["merge-driver", str(base), str(ours), str(theirs)]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertEqual(self._merged_files(), {"b.bin": "hb"})
+
+    def test_same_path_different_hashes_conflicts(self):
+        base = self._manifest("base.yaml", {"a.bin": "h0"})
+        ours = self._manifest("ours.yaml", {"a.bin": "h1"})
+        theirs = self._manifest("theirs.yaml", {"a.bin": "h2"})
+
+        result = self.runner.invoke(
+            cli, ["merge-driver", str(base), str(ours), str(theirs)]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("a.bin", result.output)
+        # Our side is kept so the file stays a valid manifest to edit
+        self.assertEqual(self._merged_files(), {"a.bin": "h1"})
+
+    def test_json_output_format_from_target_name(self):
+        base = self._manifest("base.yaml", {})
+        ours = self._manifest("ours.yaml", {"a.bin": "ha"})
+        theirs = self._manifest("theirs.yaml", {"b.bin": "hb"})
+
+        result = self.runner.invoke(
+            cli,
+            [
+                "merge-driver",
+                str(base),
+                str(ours),
+                str(theirs),
+                ".s3_manifest.json",
+            ],
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        data = json.loads((self.temp_dir / "ours.yaml").read_text())
+        self.assertEqual(data["files"], {"a.bin": "ha", "b.bin": "hb"})
+
+
+class TestMergeDriverEndToEnd(GitRepoTestCase):
+    """git itself must invoke the driver and merge divergent branches.
+
+    Only the merge driver is registered here, not the hooks: the hooks
+    would shell out to s3lfs for real S3 work in a subprocess that moto
+    does not patch. The merge driver touches no network.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # Put an `s3lfs` on PATH for git to invoke as the merge driver.
+        self.bin_dir = Path(os.path.realpath(tempfile.mkdtemp()))
+        self.addCleanup(shutil.rmtree, self.bin_dir, ignore_errors=True)
+        repo_root = Path(__file__).resolve().parent.parent
+        shim = self.bin_dir / "s3lfs"
+        shim.write_text(
+            "#!/bin/sh\n"
+            f'PYTHONPATH="{repo_root}" exec "{sys.executable}" '
+            '-m s3lfs.cli "$@"\n'
+        )
+        shim.chmod(0o755)
+        self.env = dict(os.environ)
+        self.env["PATH"] = f"{self.bin_dir}:{self.env['PATH']}"
+
+        _install_merge_driver(Path(self.temp_dir))
+
+    def _git_with_shim(self, *args):
+        return subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            cwd=self.temp_dir,
+            env=self.env,
+        )
+
+    def test_git_merge_unions_divergent_branches(self):
+        self._commit_all("register merge driver")
+        default_branch = self._git("branch", "--show-current").stdout.strip()
+
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+
+        self._git("checkout", "-b", "feature", default_branch + "~1")
+        self._write("data/b.bin", "b")
+        self.runner.invoke(cli, ["track", "data/b.bin"])
+        self._commit_all("track b")
+
+        self._git("checkout", default_branch)
+        merge = self._git_with_shim("merge", "feature", "--no-edit")
+        self.assertEqual(merge.returncode, 0, msg=merge.stdout + merge.stderr)
+
+        files = yaml.safe_load(Path(".s3_manifest.yaml").read_text())["files"]
+        self.assertIn("data/a.bin", files)
+        self.assertIn("data/b.bin", files)
+
+        # The .gitignore block must union too, and stay a single block
+        _, entries, _ = _load_gitignore_block(Path(self.temp_dir))
+        self.assertIn("/data/a.bin", entries)
+        self.assertIn("/data/b.bin", entries)
+        content = Path(".gitignore").read_text()
+        self.assertEqual(content.count(S3LFS_GITIGNORE_START), 1)
+
+    def test_git_merge_reports_real_manifest_conflict(self):
+        """Both branches changing the same path to different content is a
+        genuine conflict and must still stop the merge."""
+        self._write("data/a.bin", "base")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+        default_branch = self._git("branch", "--show-current").stdout.strip()
+
+        self._git("checkout", "-b", "feature")
+        self._write("data/a.bin", "theirs")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("their a")
+
+        self._git("checkout", default_branch)
+        self._write("data/a.bin", "ours")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("our a")
+
+        merge = self._git_with_shim("merge", "feature", "--no-edit")
+        self.assertNotEqual(merge.returncode, 0, "real conflict was silently merged")
+        self.assertIn("data/a.bin", merge.stdout + merge.stderr)
+
+
+class TestGitignoreMerge(unittest.TestCase):
+    """Unit-level checks on the .gitignore three-way merge."""
+
+    def setUp(self):
+        self.temp_dir = Path(os.path.realpath(tempfile.mkdtemp()))
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _side(self, name, text):
+        path = self.temp_dir / name
+        path.write_text(text)
+        return path
+
+    def _block(self, *entries):
+        lines = [S3LFS_GITIGNORE_START, *entries, S3LFS_GITIGNORE_END]
+        return "\n".join(lines) + "\n"
+
+    def test_unions_block_entries(self):
+        base = self._side("base", "*.pyc\n")
+        ours = self._side("ours", "*.pyc\n\n" + self._block("/a.bin"))
+        theirs = self._side("theirs", "*.pyc\n\n" + self._block("/b.bin"))
+
+        merged, conflict = _merge_gitignore(base, ours, theirs)
+
+        self.assertFalse(conflict)
+        self.assertIn("*.pyc", merged)
+        self.assertIn("/a.bin", merged)
+        self.assertIn("/b.bin", merged)
+        self.assertEqual(merged.count(S3LFS_GITIGNORE_START), 1)
+
+    def test_entry_removed_on_one_side_stays_removed(self):
+        base = self._side("base", self._block("/a.bin", "/b.bin"))
+        ours = self._side("ours", self._block("/a.bin", "/b.bin"))
+        theirs = self._side("theirs", self._block("/b.bin"))
+
+        merged, conflict = _merge_gitignore(base, ours, theirs)
+
+        self.assertFalse(conflict)
+        self.assertNotIn("/a.bin", merged)
+        self.assertIn("/b.bin", merged)
+
+    def test_conflicting_user_edits_are_reported(self):
+        base = self._side("base", "shared\n")
+        ours = self._side("ours", "ours-only\n")
+        theirs = self._side("theirs", "theirs-only\n")
+
+        merged, conflict = _merge_gitignore(base, ours, theirs)
+
+        self.assertTrue(conflict, "conflicting user edits should not merge silently")
+        self.assertIn("<<<<<<<", merged)
+
+
+class TestInstallRegistersMergeDriver(GitRepoTestCase):
+    def test_install_writes_gitattributes_and_config(self):
+        result = self.runner.invoke(cli, ["install"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        attributes = Path(".gitattributes").read_text()
+        self.assertIn(".s3_manifest.yaml merge=s3lfs", attributes)
+
+        driver = self._git("config", "merge.s3lfs.driver").stdout.strip()
+        self.assertIn("s3lfs merge-driver", driver)
+
+    def test_uninstall_removes_registration(self):
+        self.runner.invoke(cli, ["install"])
+        result = self.runner.invoke(cli, ["uninstall"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        attributes = Path(".gitattributes")
+        if attributes.exists():
+            self.assertNotIn("merge=s3lfs", attributes.read_text())
+        self.assertEqual(self._git("config", "merge.s3lfs.driver").stdout.strip(), "")
+
+    def test_install_preserves_existing_gitattributes(self):
+        Path(".gitattributes").write_text("*.txt text\n")
+        self.runner.invoke(cli, ["install"])
+        self.runner.invoke(cli, ["uninstall"])
+
+        self.assertIn("*.txt text", Path(".gitattributes").read_text())
+
+
+class TestCloneCommand(GitRepoTestCase):
+    """s3lfs clone: clone + hooks + download in one command."""
+
+    def _make_source_repo(self):
+        self._write("data/a.bin", "payload")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+        return self.temp_dir
+
+    def test_clone_installs_hooks_and_downloads_files(self):
+        source = self._make_source_repo()
+        dest = Path(os.path.realpath(tempfile.mkdtemp())) / "cloned"
+        self.addCleanup(shutil.rmtree, dest.parent, ignore_errors=True)
+
+        result = self.runner.invoke(cli, ["clone", source, str(dest)])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        # The tracked file is gitignored, so it can only be here via S3
+        self.assertTrue((dest / "data/a.bin").exists())
+        self.assertEqual((dest / "data/a.bin").read_text(), "payload")
+        self.assertTrue((dest / ".git/hooks/pre-commit").exists())
+
+    def test_clone_no_checkout_skips_download(self):
+        source = self._make_source_repo()
+        dest = Path(os.path.realpath(tempfile.mkdtemp())) / "cloned"
+        self.addCleanup(shutil.rmtree, dest.parent, ignore_errors=True)
+
+        result = self.runner.invoke(cli, ["clone", source, str(dest), "--no-checkout"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertFalse((dest / "data/a.bin").exists())
+        self.assertTrue((dest / ".git/hooks/pre-commit").exists())
+
+    def test_clone_non_s3lfs_repo_reports_and_stops(self):
+        self._write("readme.txt", "hello")
+        Path(".s3_manifest.yaml").unlink()
+        self._commit_all("plain repo")
+
+        dest = Path(os.path.realpath(tempfile.mkdtemp())) / "cloned"
+        self.addCleanup(shutil.rmtree, dest.parent, ignore_errors=True)
+
+        result = self.runner.invoke(cli, ["clone", self.temp_dir, str(dest)])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("not s3lfs-initialized", result.output)
+        self.assertTrue((dest / "readme.txt").exists())
+
+    def test_clone_restores_cwd(self):
+        source = self._make_source_repo()
+        dest = Path(os.path.realpath(tempfile.mkdtemp())) / "cloned"
+        self.addCleanup(shutil.rmtree, dest.parent, ignore_errors=True)
+
+        before = Path.cwd()
+        self.runner.invoke(cli, ["clone", source, str(dest)])
+        self.assertEqual(Path.cwd(), before)
 
 
 if __name__ == "__main__":

--- a/tests/test_install_hooks.py
+++ b/tests/test_install_hooks.py
@@ -206,7 +206,13 @@ class TestInstallCommand(unittest.TestCase):
         self.assertEqual(result.exit_code, 0, msg=result.output)
 
         hooks_dir = Path(self.temp_dir) / ".git" / "hooks"
-        for hook_name in ["post-merge", "post-checkout", "pre-commit", "pre-push"]:
+        for hook_name in [
+            "post-merge",
+            "post-checkout",
+            "post-rewrite",
+            "pre-commit",
+            "pre-push",
+        ]:
             hook_path = hooks_dir / hook_name
             self.assertTrue(hook_path.exists(), f"{hook_name} not created")
             content = hook_path.read_text()
@@ -270,7 +276,7 @@ class TestInstallCommand(unittest.TestCase):
         runner = CliRunner()
         runner.invoke(cli, ["install"])
 
-        for hook_name in ["post-merge", "post-checkout"]:
+        for hook_name in ["post-merge", "post-checkout", "post-rewrite"]:
             hook_path = Path(self.temp_dir) / ".git" / "hooks" / hook_name
             content = hook_path.read_text()
             self.assertIn("ERROR", content, f"{hook_name} should report failure")
@@ -305,7 +311,13 @@ class TestInstallCommand(unittest.TestCase):
         runner = CliRunner()
         runner.invoke(cli, ["install"])
 
-        for hook_name in ["post-merge", "post-checkout", "pre-commit", "pre-push"]:
+        for hook_name in [
+            "post-merge",
+            "post-checkout",
+            "post-rewrite",
+            "pre-commit",
+            "pre-push",
+        ]:
             hook_path = Path(self.temp_dir) / ".git" / "hooks" / hook_name
             content = hook_path.read_text()
             self.assertIn("command -v s3lfs", content)
@@ -342,7 +354,13 @@ class TestUninstallCommand(unittest.TestCase):
         self.assertIn("Removed", result.output)
 
         hooks_dir = Path(self.temp_dir) / ".git" / "hooks"
-        for hook_name in ["post-merge", "post-checkout", "pre-commit", "pre-push"]:
+        for hook_name in [
+            "post-merge",
+            "post-checkout",
+            "post-rewrite",
+            "pre-commit",
+            "pre-push",
+        ]:
             hook_path = hooks_dir / hook_name
             if hook_path.exists():
                 content = hook_path.read_text()


### PR DESCRIPTION
## Summary

Continues the git-workflow integration work from #105, closing the remaining gaps between s3lfs and a git-lfs-like experience.

### 1. Cheap branch switches (`s3lfs sync`)

The post-checkout and post-merge hooks ran `checkout --all`, which re-hashes **every** tracked file on every branch switch — O(total asset size) even for a no-op switch. Since the manifest is itself in git, it can be diffed.

New **`s3lfs sync [--from REV]`** compares the manifest at `REV` against the working-tree manifest and:
- downloads only added/changed entries (then skips any that already have the right content on disk),
- deletes files the manifest no longer lists — mirroring what git does for files absent from the target branch — but **only when their content still matches what the old manifest recorded**, so local modifications are never destroyed (`--no-prune` disables it entirely),
- cleans up directories left empty,
- falls back to a full checkout when the baseline revision is unavailable (fresh clone, shallow history, revision predating s3lfs).

The post-checkout hook passes `$1` (previous HEAD) and post-merge passes `ORIG_HEAD`.

### 2. `post-rewrite` hook

`git pull --rebase` fires neither post-merge nor a branch post-checkout, so the most common pull configuration left tracked files stale. Added a post-rewrite hook (rebase only; amends leave ORIG_HEAD stale and rarely touch the manifest).

### 3. `s3lfs status`

Tracked files are gitignored, so `git status` can't see them. `s3lfs status` reports up-to-date / modified / missing using the hash cache, with an optional path filter, `--all`, and `--porcelain` (`M` / `D` codes) for scripting.

### 4. Conflict-free manifests (merge driver)

Two branches that each track a different file both rewrite `.s3_manifest.yaml` **and** `.gitignore`, and git's line-based merge calls both a conflict — even though the change is a clean union. (The `.gitignore` half of this was a papercut #105 introduced.)

`s3lfs install` now registers a merge driver that merges the manifest key-wise and the `.gitignore` s3lfs block as a set union, delegating the rest of `.gitignore` to `git merge-file` so user entries behave normally. A conflict is only reported when both sides change the same path to different content. The `.gitattributes` entry is committed so teammates inherit the rule; the driver is local config, and git falls back to its normal merge for anyone who hasn't run `s3lfs install`.

### 5. `s3lfs clone`

Hooks live in `.git` and are never cloned. `s3lfs clone <url> [dir]` does clone + install + `checkout --all` in one command.

## Notable behavior change

With `--from`, a tracked file the user deleted that is *identical* in both revisions is no longer restored on branch switch — it isn't part of the diff. This matches git's own semantics for files that don't differ between branches, `s3lfs status` now surfaces them, and `s3lfs checkout --all` still restores everything.

## Testing

- 33 new tests in `tests/test_git_integration.py`: sync (diff-only downloads, pruning, the modified-file safety guard, fallbacks), status (all three states, porcelain, filters), the merge driver (unit-level three-way cases plus two **end-to-end `git merge` runs** through a PATH shim — one asserting a clean union, one asserting a real conflict still stops the merge), `.gitignore` merge, install/uninstall registration, and clone.
- Updated hook tests for the new hook set.
- Full suite: 799 passed, 3 skipped; black/isort/flake8/mypy clean.

Also fixes a **pre-existing failure on main** (unrelated to this work): `test_load_cache_stat_oserror` counted `Path.stat` calls on the assumption that `Path.exists()` routes through `Path.stat`, which is no longer true on Python 3.14. It now patches both explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)