### PR TITLE
Verify data-integrity properties in TLA+, and fix what the models found

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,9 +26,22 @@ jobs:
         run: uv run pre-commit run --all-files
 
   test:
-    name: Run Tests
-    runs-on: ubuntu-latest
+    name: Tests (Python ${{ matrix.python-version }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     needs: lint
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # The floor and the ceiling of the supported range on Linux, plus a
+        # macOS run: s3lfs shells out to git constantly and writes /bin/sh
+        # hooks, so a second platform is worth more than a third minor
+        # version.
+        os: [ubuntu-latest]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        include:
+          - os: macos-latest
+            python-version: "3.13"
 
     steps:
       - name: Checkout repository
@@ -38,18 +51,45 @@ jobs:
         uses: astral-sh/setup-uv@v4
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --python ${{ matrix.python-version }}
+
+      - name: Show versions
+        run: |
+          uv run python -V
+          git --version
 
       - name: Run Tests
         run: uv run pytest --cov=s3lfs --cov-report=xml
 
       - name: Upload coverage reports to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           slug: kmatzen/s3lfs
           fail_ci_if_error: false
+
+  verify:
+    name: Model checking (TLA+)
+    runs-on: ubuntu-latest
+    needs: lint
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "21"
+
+      # Checks both directions: properties that must hold, and models of
+      # known defects that must still violate their invariant -- otherwise
+      # the property is vacuous and proves nothing.
+      - name: Check TLA+ models
+        run: ./specs/check.sh
 
   integration:
     name: Integration Tests (MinIO)

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ build/
 
 # Virtual environments
 .venv/
+
+# TLA+ model checker, downloaded on demand (see specs/README.md)
+specs/tla2tools.jar
+specs/states/
+
+# >>> s3lfs tracked files >>>
+/test_cli_file.txt
+# <<< s3lfs tracked files <<<

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2026-08-08
 
 ### Added
 - Sparse checkout support: s3lfs now applies the working copy's `git sparse-checkout` rules to tracked files, so a large repository can be checked out one slice at a time. Rules are matched by `git sparse-checkout check-rules` (git's own matcher, cone and non-cone), because tracked files are gitignored and therefore invisible to git's own sparse machinery. `sync` downloads only in-profile files and prunes ones that leave the profile, `checkout --all` means "everything this working copy materializes", `status` hides out-of-profile files behind a count, and the pre-commit hook walks only the slice so commit cost tracks the working copy rather than the repository. Requires git 2.42+; degrades to treating everything as in-profile (with a warning) otherwise, so it can only ever over-download.
+- `specs/S3lfsOwnership.tla`: a TLA+ model of git/s3lfs file ownership, checking that no path is versioned by both systems at once and that no file on disk is hidden from git while absent from the manifest. `IGNORE_SCOPE = "directory"` reproduces the over-broad ignore defect.
+- `specs/S3lfsWorkingCopy.tla`: a TLA+ model of the working-copy lifecycle (track, remove, commit, branch switch, sync, cleanup) checking that content existing only on disk is never destroyed, that every manifest entry has an object behind it, and that distinct paths never share a storage key. Constants isolate the two design decisions those properties depend on; TLC confirms each is load-bearing by violating an invariant when it is disabled.
 - `s3lfs sparse` command: shows whether sparse checkout is active, the patterns in effect, and how many tracked files are materialized here
 - `s3lfs sync [--from REV]` command: brings tracked files in line with the manifest by diffing against a revision's manifest, transferring only what changed and removing files the manifest no longer lists (only when their content still matches what it recorded). Replaces the blanket `checkout --all` in the post-checkout and post-merge hooks, which re-hashed every tracked file on every branch switch.
 - `post-rewrite` git hook, so `git pull --rebase` -- which fires neither post-merge nor a branch post-checkout -- no longer leaves tracked files stale
@@ -23,17 +25,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Manifest and cache YAML now use the libyaml-backed loader and dumper when available, which parses roughly 8x faster (4.31s to 0.50s for a 100,000-entry manifest) and emits byte-identical output. Every command reads the whole manifest, so this is felt everywhere.
 - The pre-push hook now verifies that pushed manifests reference uploaded content (`s3lfs verify`) instead of uploading at push time. Uploading during pre-push updated only the working-tree manifest, so the commits being pushed still referenced the old hashes; uploads now happen in the pre-commit hook where the manifest change lands in the commit itself.
+- CI now tests Python 3.9 through 3.13 on Linux plus a macOS run. It previously tested whatever single interpreter the runner happened to provide, so the declared 3.9 floor was never exercised -- and a Python 3.14 pathlib change had already broken a test here.
+- README no longer calls `cleanup` "experimental and untested": it has substantial test coverage and is the only subsystem with TLA+ models behind it. The warning was steering people away from the most rigorously verified code in the project.
+- The TLA+ spec notes now cite functions instead of line numbers, which had drifted far enough to point at the wrong code.
 
 ### Fixed
+- **`sync` no longer deletes the last copy of content that is no longer in S3.** The clobber guard added earlier asked only whether a file still matched the hash the manifest recorded -- but that object may since have been garbage-collected, in which case the copy on disk is the only one. TLC found the trace (`track`, commit, `remove`, `cleanup`, `sync`) against the new `S3lfsWorkingCopy` model, and the rule was strengthened to what the model requires: only take bytes off disk when those bytes can be fetched back.
 - **`sync` no longer overwrites locally modified tracked files.** It compared disk content only against the *target* hash, so a file edited but not yet uploaded counted as "needs downloading" and was silently replaced -- no warning, no backup, from an automatic post-checkout hook. Tracked files are gitignored, so git could not warn either. It now also compares against the previous revision's hash: a file holding the content the old manifest recorded is safe to update, anything else is reported and kept. `--force` restores the old behaviour, and the no-baseline path (which cannot tell the two apart) keeps modified files too.
 - **`s3lfs install` no longer installs dead code.** A block appended to an existing hook ending in `exit 0` -- git's own samples, husky, and many CI scaffolds do -- was never reached while install reported success, so nothing uploaded at commit and nothing verified at push. The block is now placed where it runs, and a hook whose interpreter is not a POSIX shell is refused with an explanation rather than corrupted.
 - **Read-only commands no longer rewrite the manifest.** `S3LFS.__init__` saved unconditionally, so `status`, `sparse`, `ls`, `verify` and every sync hook dirtied the git-tracked manifest, breaking clean-tree checks and able to overwrite an unresolved merge. It now writes only when construction actually changed the stored configuration.
 - **`s3lfs track <dir>` no longer hides later files from git.** It wrote `/<dir>/`, ignoring everything under that directory forever, so a source file added there afterwards was invisible to git (ignored) *and* to s3lfs (not in the manifest) -- present on one machine only. Literal specs now expand to one entry per tracked file, globs are kept as-is, and gitignore metacharacters are escaped so a directory like `runs[2024]` matches literally instead of as a character class.
 - **`s3lfs track` reports when it tracks nothing.** A path outside the repository -- including a symlink pointing outside it -- was skipped with no output and exit 0, leaving the user believing a large file was safely in S3.
+- `s3lfs install` no longer crashes in a linked worktree or submodule, where `.git` is a file rather than a directory. It asks git where the hooks live (`git rev-parse --git-path hooks`) instead of assuming.
+- `s3lfs sync` on a branch from before s3lfs existed now says there is nothing to sync instead of erroring, so the post-checkout hook stops reporting a failure for an ordinary checkout.
+- A manifest that cannot be parsed now produces an explanation rather than a bare YAML traceback, and names merge conflict markers when it finds them -- the state a teammate who has not run `s3lfs install` will hit.
+- A revision whose manifest is unparseable or is not a manifest at all (a directory at that path, a commit with conflict markers) is treated as "no baseline" rather than raising out of a hook.
+- The merge driver keeps keys whose value is legitimately null instead of reading them as deleted, detects `.gitignore` by content when git does not pass the path, and no longer claims git will "fall back" on failure -- git does not, so the message now says the file needs resolving by hand.
+- `verify --revision` warns when that revision recorded a different bucket or prefix, which would otherwise make it check the wrong location and report false missing content.
+- `pre-commit` stages `.gitignore` alongside the manifest and fails loudly if staging fails, instead of letting a commit record old hashes while the new content is already in S3.
+- S3 listings used to derive chunk counts now follow continuation tokens; a truncated listing at 1000 keys would have silently rebuilt a short file. The loop continues only on a genuine continuation token, so an unexpected response shape cannot spin it forever.
+- `git ls-files -z` output and `git rm` pathspecs are handled as bytes, so paths containing a carriage return are not mangled.
+- `s3lfs sparse` reports a profile it could not apply even when the failure happens mid-listing.
 - `sync --prune` keeps going and reports failures when a file cannot be removed, instead of aborting mid-loop with no summary.
 - `test_load_cache_stat_oserror` assumed `Path.exists()` is implemented in terms of `Path.stat`, which is no longer true on Python 3.14; the test now patches both explicitly
 
-## [0.2.0] - 2026-04-11
+## [0.2.0] - 2026-04-11 (never published)
+
+This version was tagged in the changelog but no release was ever cut, so it
+never reached PyPI. Everything below shipped in 0.3.0 instead.
 
 ### Added
 - `--endpoint-url` flag for S3-compatible storage (MinIO, Cloudflare R2, Backblaze B2, Wasabi)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,60 @@
+# Contributing to s3lfs
+
+Thanks for your interest. Issues and pull requests are welcome.
+
+## Getting set up
+
+```sh
+pip install uv
+uv sync
+uv run pytest
+```
+
+Install the pre-commit hooks so formatting and linting run automatically:
+
+```sh
+uv run pre-commit install
+```
+
+They run black (88 columns), isort (black profile), flake8, mypy, and the
+test suite.
+
+## What CI checks
+
+- Tests on Python 3.9 through 3.13 on Linux, plus a macOS run
+- An integration job that runs the suite against a real MinIO server
+- The pre-commit hooks above, on all files
+
+Python 3.9 is the supported floor, so avoid 3.10+ syntax: no `X | Y`
+annotations, no subscripted builtins (`list[str]`) evaluated at runtime, no
+`match` statements, no `str.removeprefix`.
+
+## Writing tests
+
+Tests use `moto` to mock S3. Anything touching git should build a real
+temporary repository and run real git commands rather than mocking git —
+several bugs in this project came from assumptions about git's behaviour
+that only a real repository disproves.
+
+When you fix a bug, add the test that reproduces it first. A test that
+passes before your change is not testing the fix.
+
+## Things worth knowing
+
+- **The manifest is a git-tracked file.** Anything that writes it on a
+  read-only code path will dirty a user's working tree.
+- **Tracked files are gitignored**, so git cannot warn a user that one has
+  local modifications. Code that overwrites or deletes tracked content is
+  the only thing standing between that content and permanent loss — check
+  the recorded hash before touching a file.
+- **Hooks run in other people's repositories.** A hook that fails loudly is
+  recoverable; one that silently does nothing is not.
+- **The concurrency-sensitive protocols have TLA+ models** in [`specs/`](specs/).
+  If you change garbage collection, chunked upload, or manifest locking,
+  read the relevant model first — it probably already describes the failure
+  you are about to reintroduce.
+
+## Commit messages
+
+Explain why the change is needed, not just what it does. If it fixes a
+defect, describe the failure the user would have seen.

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ s3lfs remove data/ --purge-from-s3       # Remove and delete from S3
 
 ### Cleanup Unreferenced Files
 
-> ⚠️ **Work in Progress**: The cleanup command is experimental and untested. Use with caution.
-
 ```sh
 s3lfs cleanup
 ```
 **Description**: Removes files from S3 that are no longer referenced in the current manifest.
+
+Reachability is computed on path *and* content hash, matching the storage layout, and uploads in flight are protected by a registry so a concurrent `track` cannot have its objects collected. Both properties are modelled in TLA+ under [`specs/`](specs/) and checked with TLC. Deletion is irreversible, so review what it reports before using `--force`.
 
 **Options**:
 - `--force`: Skip confirmation prompt
@@ -507,6 +507,8 @@ The endpoint URL is stored in the manifest, so subsequent commands pick it up au
 Create a `.s3lfsconfig` file at the git root to set defaults for the whole team:
 ```yaml
 # .s3lfsconfig - commit this to version control
+endpoint_url: https://minio.internal:9000
+workers: 16
 no_sign_request: true
 use_acceleration: false
 ```
@@ -516,6 +518,10 @@ When `.s3lfsconfig` exists, its values are used as defaults for all commands. CL
 **Supported keys**:
 - `no_sign_request`: Use unsigned S3 requests (default: `false`)
 - `use_acceleration`: Enable S3 Transfer Acceleration (default: `false`)
+- `endpoint_url`: S3-compatible endpoint for the whole team (default: none, i.e. AWS)
+- `workers`: Parallel worker count (default: auto-detected from CPU count)
+
+Unrecognised keys are reported rather than ignored -- a misspelled setting that changes where your data goes should not fail silently.
 
 ### Public Buckets
 For public S3 buckets, use the `--no-sign-request` flag or set it in `.s3lfsconfig`:
@@ -567,6 +573,37 @@ Files with identical content (same hash) are stored only once in S3, regardless 
 S3LFS supports both SHA-256 (default) and MD5 hashing:
 - SHA-256: More secure, used for file integrity
 - MD5: Available for compatibility with legacy systems
+
+## Correctness
+
+The parts of s3lfs that can lose data are modelled in TLA+ and checked with TLC
+on every pull request. The models live in [`specs/`](specs/); `specs/check.sh`
+runs them.
+
+What is checked:
+
+| Property | Meaning |
+|---|---|
+| `NoDataLoss` | No automatic operation destroys content that exists only on disk |
+| `NoDanglingReference` | Every manifest entry has an object behind it, so a checkout cannot 404 |
+| `NoCollateralDeletion` | Distinct paths never share a storage key, so untracking one never destroys another's bytes |
+| `NoDualOwnership` | No path is versioned by git and s3lfs at the same time |
+| `NoOrphanedFile` | No file on disk is hidden from git while absent from the manifest |
+| `NoSilentCorruption` | A checkout that reports success produced the whole file |
+| `NoLostUpdate` | Concurrent manifest writers do not overwrite each other |
+
+Each property is paired with a configuration that *disables* the design decision
+it depends on, and CI asserts those still fail. A property that holds no matter
+what the code does proves nothing, so both directions are checked.
+
+This is model checking, not a proof about the Python. The models are hand-written
+abstractions of the implementation over small bounded domains -- a few paths, a
+few content values -- so they establish that the *design* is sound and that
+specific defects are excluded, not that the code is free of bugs. Their practical
+value is concrete: checking the working-copy model produced a counterexample
+(`track` → commit → `remove` → `cleanup` → `sync`) that revealed `sync` would
+delete the last copy of content whose object had been garbage-collected. That
+trace is now a regression test.
 
 ## Troubleshooting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Supported versions
+
+Fixes land on `main` and go out in the next release. Only the latest
+release is supported.
+
+## Reporting a vulnerability
+
+Please report security issues privately via
+[GitHub's private vulnerability reporting](https://github.com/kmatzen/s3lfs/security/advisories/new)
+rather than opening a public issue.
+
+Include what you can: affected version, reproduction steps, and what an
+attacker gains. You can expect an initial response within a week.
+
+## Scope notes
+
+s3lfs runs as you, with your AWS credentials, and installs git hooks that
+execute on ordinary git commands. A few consequences worth stating plainly:
+
+- **Cloning a repository does not install hooks.** Git never transfers
+  hooks, and `s3lfs install` is an explicit step. But `s3lfs clone` does
+  install them, so treat it as you would any "clone and set up" command:
+  only run it against repositories you trust.
+- **The manifest determines where data is read from and written to.** It is
+  a version-controlled file, so a malicious change to `bucket_name`,
+  `repo_prefix`, or `endpoint_url` in a pull request would redirect your
+  uploads. Review changes to `.s3_manifest.yaml` and `.s3lfsconfig` the way
+  you would review changes to CI configuration.
+- **`s3lfs cleanup` deletes S3 objects** that the current manifest does not
+  reference. Deletion is irreversible; enable bucket versioning if that
+  matters to you.
+
+Credentials are handled entirely by boto3 — s3lfs never reads, stores, or
+logs them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3lfs"
-version = "0.2.0"
+version = "0.3.0"
 description = "A Python-based version control system for large assets using Amazon S3."
 authors = [{name = "Kevin Blackburn-Matzen", email = "kmatzen@gmail.com"}]
 license = {text = "MIT"}
@@ -18,6 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Version Control",
     "Topic :: System :: Archiving",
     "Typing :: Typed",

--- a/s3lfs/__init__.py
+++ b/s3lfs/__init__.py
@@ -7,8 +7,17 @@ with support for file tracking, parallel operations, encryption, and
 automatic cleanup of unused assets.
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _installed_version
+
 from . import metrics
 from .core import S3LFS
 
-__version__ = "0.2.0"
+try:
+    # Read the version from installed package metadata so it cannot drift
+    # from pyproject.toml -- there is only one place to bump.
+    __version__ = _installed_version("s3lfs")
+except PackageNotFoundError:  # pragma: no cover - running from a source tree
+    __version__ = "0.0.0+unknown"
+
 __all__ = ["S3LFS", "metrics", "__version__"]

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -6,6 +6,7 @@ import tempfile
 from pathlib import Path
 
 import click
+import yaml
 
 from s3lfs import metrics
 from s3lfs.config import load_config
@@ -26,6 +27,13 @@ def _make_s3lfs(
     # CLI True overrides config; CLI False falls back to config
     effective_no_sign = no_sign_request or config.get("no_sign_request", False)
     effective_accel = use_acceleration or config.get("use_acceleration", False)
+
+    # For non-boolean settings an unset CLI option arrives as None, so the
+    # config supplies the value only when the flag was not given.
+    for key in ("endpoint_url", "workers"):
+        if extra.get(key) is None and config.get(key) is not None:
+            extra[key] = config[key]
+
     return S3LFS(
         no_sign_request=effective_no_sign,
         manifest_file=str(manifest_path),
@@ -106,6 +114,7 @@ def get_manifest_path(git_root):
 
 
 @click.group()
+@click.version_option(package_name="s3lfs", prog_name="s3lfs")
 def cli():
     """S3-based asset versioning CLI tool."""
     pass
@@ -320,6 +329,23 @@ def checkout(
         raise click.Abort()
 
 
+def _recoverable(s3lfs, on_disk):
+    """Which of these paths hold content that can be fetched back from S3.
+
+    This is the condition under which taking bytes off disk loses nothing,
+    and it is deliberately stronger than "matches the hash the manifest
+    recorded". A file can match a recorded hash whose object has since been
+    garbage-collected, in which case the copy on disk is the last one.
+    TLC found exactly that trace against the weaker rule -- track, commit,
+    remove, cleanup, sync -- see specs/S3lfsWorkingCopy.tla.
+    """
+    present = {key: h for key, h in on_disk.items() if h is not None}
+    if not present:
+        return set()
+    missing = {key for key, _ in s3lfs.find_missing_assets(present)}
+    return set(present) - missing
+
+
 def _prune_empty_parents(git_root, path):
     """Remove directories left empty by a deleted file, up to the git root."""
     parent = path.parent
@@ -382,8 +408,20 @@ def sync(
     actually changed. Used by the post-checkout, post-merge, and
     post-rewrite hooks.
     """
-    git_root, manifest_path, path_resolver = _setup_s3lfs_command()
+    git_root = find_git_root()
+    if not git_root:
+        click.echo("Error: Not in a git repository")
+        raise click.Abort()
 
+    manifest_path = get_manifest_path(git_root)
+    if not manifest_path.exists():
+        # Checking out a branch from before s3lfs was introduced is a normal
+        # thing to do; the post-checkout hook must not report an error for
+        # it. There is nothing to sync to, so say so and stop.
+        click.echo("No s3lfs manifest here; nothing to sync.")
+        return
+
+    path_resolver = PathResolver(git_root)
     s3lfs = _make_s3lfs(
         git_root,
         manifest_path,
@@ -426,35 +464,35 @@ def sync(
             click.echo("Tracked files are already in sync.")
             return
         if changed:
-            # Two questions, two comparisons. Against the *new* hash: does
-            # this file already hold the target content, so no transfer is
-            # needed? Against the *old* hash: is what is on disk the content
-            # the previous manifest recorded, so overwriting it loses
-            # nothing? A file matching neither has been edited locally, and
-            # since tracked files are gitignored, git never warned about it
-            # and this is the only thing standing between that work and a
-            # silent overwrite.
-            at_target = s3lfs.compare_to_hashes(changed, progress=verbose)
-            baseline = {k: previous[k] for k in changed if k in previous}
-            at_baseline = s3lfs.compare_to_hashes(baseline, progress=verbose)
+            on_disk = s3lfs.disk_hashes(changed, progress=verbose)
+            # Only files that exist and do not already hold the target
+            # content can lose anything, so only those are worth an S3
+            # round trip. Most of a branch switch is absent or already
+            # correct files.
+            at_risk = {
+                key: h
+                for key, h in on_disk.items()
+                if h is not None and h != changed[key]
+            }
+            recoverable = _recoverable(s3lfs, at_risk)
 
             to_download = []
             locally_modified = []
             for key in changed:
-                if at_target.get(key) == "up_to_date":
-                    continue
-                if at_target.get(key) == "missing":
-                    to_download.append((key, changed[key]))
-                elif force or at_baseline.get(key) == "up_to_date":
+                if on_disk.get(key) == changed[key]:
+                    continue  # already holds the target content
+                if on_disk.get(key) is None:
+                    to_download.append((key, changed[key]))  # nothing to lose
+                elif force or key in recoverable:
                     to_download.append((key, changed[key]))
                 else:
                     locally_modified.append(key)
 
             if locally_modified:
                 click.echo(
-                    f"Keeping {len(locally_modified)} locally modified file(s); "
-                    "upload with 's3lfs track --modified', or discard with "
-                    "'s3lfs sync --force':"
+                    f"Keeping {len(locally_modified)} file(s) whose content is "
+                    "not in S3; upload with 's3lfs track --modified', or "
+                    "discard with 's3lfs sync --force':"
                 )
                 for key in sorted(locally_modified):
                     click.echo(f"  {key}")
@@ -466,19 +504,17 @@ def sync(
                 click.echo(f"{len(changed)} changed entr(y/ies) already up-to-date.")
 
     if to_remove and prune:
-        # Only remove content that still matches the hash recorded for it.
-        # Anything else is local work, and deleting it would destroy the
-        # only copy.
-        states = s3lfs.compare_to_hashes(to_remove, progress=verbose)
+        on_disk = s3lfs.disk_hashes(to_remove, progress=verbose)
+        recoverable = _recoverable(s3lfs, on_disk)
         removed = 0
         failed = []
-        for key, state in sorted(states.items()):
-            if state == "missing":
+        for key in sorted(to_remove):
+            if on_disk.get(key) is None:
                 continue
-            if state == "modified" and not force:
+            if not force and key not in recoverable:
                 click.echo(
-                    f"Keeping {key}: it is no longer materialized here but has "
-                    "local modifications."
+                    f"Keeping {key}: it is no longer materialized here, and "
+                    "its content is not in S3 to fetch back."
                 )
                 continue
             filesystem_path = path_resolver.to_filesystem_path(key)
@@ -1166,14 +1202,30 @@ def _save_marked_block(path, start_marker, end_marker, before, entries, after):
     path.write_text("\n".join(lines) + ("\n" if lines else ""))
 
 
-def _add_marked_entry(path, start_marker, end_marker, entry):
-    """Add an entry to a marked block. Returns True if it was added."""
+def _add_marked_entries(path, start_marker, end_marker, new_entries):
+    """Add entries to a marked block in one pass. Returns those added.
+
+    Adding them one at a time would re-read and rewrite the whole file per
+    entry, which is quadratic in the number of tracked files -- and
+    `track` on a large directory adds one entry per file.
+    """
     before, entries, after = _load_marked_block(path, start_marker, end_marker)
-    if entry in entries:
-        return False
-    entries.append(entry)
-    _save_marked_block(path, start_marker, end_marker, before, entries, after)
-    return True
+    have = set(entries)
+    added = []
+    for entry in new_entries:
+        if entry in have:
+            continue
+        have.add(entry)
+        entries.append(entry)
+        added.append(entry)
+    if added:
+        _save_marked_block(path, start_marker, end_marker, before, entries, after)
+    return added
+
+
+def _add_marked_entry(path, start_marker, end_marker, entry):
+    """Add a single entry to a marked block. Returns True if it was added."""
+    return bool(_add_marked_entries(path, start_marker, end_marker, [entry]))
 
 
 def _remove_marked_entries(path, start_marker, end_marker, entry_variants):
@@ -1197,6 +1249,13 @@ def _add_gitignore_entry(git_root, entry):
     """Add an entry to the s3lfs block in .gitignore. Returns True if added."""
     return _add_marked_entry(
         git_root / ".gitignore", S3LFS_GITIGNORE_START, S3LFS_GITIGNORE_END, entry
+    )
+
+
+def _add_gitignore_entries(git_root, entries):
+    """Add several entries to the s3lfs block in one read-modify-write."""
+    return _add_marked_entries(
+        git_root / ".gitignore", S3LFS_GITIGNORE_START, S3LFS_GITIGNORE_END, entries
     )
 
 
@@ -1254,15 +1313,16 @@ def _deindex_tracked_files(git_root, tracked_keys):
 
     Returns the list of paths that were removed.
     """
+    # Bytes, not text: universal-newline translation would mangle a path
+    # containing a carriage return in NUL-delimited output.
     result = subprocess.run(
         ["git", "ls-files", "-z"],
         capture_output=True,
-        text=True,
         cwd=str(git_root),
     )
     if result.returncode != 0:
         return []
-    indexed = {p for p in result.stdout.split("\0") if p}
+    indexed = {p for p in result.stdout.decode().split("\0") if p}
     offenders = sorted(indexed & set(tracked_keys))
     if not offenders:
         return []
@@ -1279,15 +1339,14 @@ def _deindex_tracked_files(git_root, tracked_keys):
             "--pathspec-from-file=-",
             "--pathspec-file-nul",
         ],
-        input="\0".join(f":(literal){p}" for p in offenders),
+        input="\0".join(f":(literal){p}" for p in offenders).encode(),
         capture_output=True,
-        text=True,
         cwd=str(git_root),
     )
     if result.returncode != 0:
         click.echo(
             "Warning: failed to remove tracked files from the git index:\n"
-            f"{result.stderr.strip()}"
+            f"{result.stderr.decode().strip()}"
         )
         return []
     return offenders
@@ -1307,11 +1366,9 @@ def _protect_tracked_path(git_root, s3lfs, manifest_key):
         )
         return
 
-    added = [
-        entry
-        for entry in _gitignore_entries_for(manifest_key, matched.keys())
-        if _add_gitignore_entry(git_root, entry)
-    ]
+    added = _add_gitignore_entries(
+        git_root, _gitignore_entries_for(manifest_key, matched.keys())
+    )
     if added:
         shown = ", ".join(f"'{e}'" for e in added[:3])
         more = f" and {len(added) - 3} more" if len(added) > 3 else ""
@@ -1330,12 +1387,8 @@ def _protect_tracked_path(git_root, s3lfs, manifest_key):
         click.echo("Commit to finalize their removal from git.")
 
 
-def _manifest_files_at_revision(git_root, revision):
-    """Load the manifest's files mapping as of a git revision.
-
-    Returns None when the revision has no manifest or is not available
-    locally (e.g. a remote sha that was never fetched).
-    """
+def _manifest_document_at_revision(git_root, revision):
+    """The manifest mapping as of a git revision, or None if unusable."""
     names = [get_manifest_path(git_root).name]
     for other in (".s3_manifest.yaml", ".s3_manifest.json"):
         if other not in names:
@@ -1348,10 +1401,37 @@ def _manifest_files_at_revision(git_root, revision):
             cwd=str(git_root),
         )
         if result.returncode == 0:
-            # yaml.safe_load handles both the YAML and JSON manifest formats
-            data = yaml_load(result.stdout) or {}
-            return data.get("files") or {}
+            # `git show` exits 0 for things that are not manifests too -- a
+            # directory at that path prints a tree listing, and a manifest
+            # committed with conflict markers is not valid YAML. Treat
+            # anything that is not a mapping as "no usable baseline" rather
+            # than raising out of a hook.
+            try:
+                data = yaml_load(result.stdout)
+            except yaml.YAMLError:
+                return None
+            return data if isinstance(data, dict) else None
     return None
+
+
+def _manifest_config_at_revision(git_root, revision):
+    """Bucket/prefix recorded in a revision's manifest (empty if unknown)."""
+    document = _manifest_document_at_revision(git_root, revision)
+    return document or {}
+
+
+def _manifest_files_at_revision(git_root, revision):
+    """Load the manifest's files mapping as of a git revision.
+
+    Returns None when the revision has no usable manifest -- absent, not
+    available locally (a remote sha never fetched), or not a manifest at
+    all.
+    """
+    document = _manifest_document_at_revision(git_root, revision)
+    if document is None:
+        return None
+    files = document.get("files")
+    return files if isinstance(files, dict) else {}
 
 
 S3LFS_HOOK_START = "# >>> s3lfs hook >>>"
@@ -1454,8 +1534,6 @@ HOOK_SCRIPTS = {
 
 def _get_hooks_dir(git_root):
     """Get the git hooks directory, respecting core.hooksPath config."""
-    import subprocess
-
     try:
         result = subprocess.run(
             ["git", "config", "core.hooksPath"],
@@ -1470,6 +1548,26 @@ def _get_hooks_dir(git_root):
             return hooks_path
     except Exception:
         pass
+
+    # Ask git where the hooks live rather than assuming .git is a directory.
+    # In a linked worktree or a submodule it is a *file* pointing elsewhere,
+    # and guessing git_root/.git/hooks makes install fail with
+    # NotADirectoryError.
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--git-path", "hooks"],
+            capture_output=True,
+            text=True,
+            cwd=str(git_root),
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            hooks_path = Path(result.stdout.strip())
+            if not hooks_path.is_absolute():
+                hooks_path = git_root / hooks_path
+            return hooks_path
+    except Exception:
+        pass
+
     return git_root / ".git" / "hooks"
 
 
@@ -1747,17 +1845,26 @@ MANIFEST_NAMES = (".s3_manifest.yaml", ".s3_manifest.json")
 MERGE_DRIVER_PATHS = MANIFEST_NAMES + (".gitignore",)
 
 
+_ABSENT = object()
+
+
 def _merge_maps(base, ours, theirs):
     """Three-way merge of two flat maps. Returns (merged, conflicting_keys).
 
     A key only conflicts when both sides changed it away from the base to
     different values; a change on one side alone (including a deletion)
     is taken as-is.
+
+    Absence is tracked with a sentinel rather than None, so a key whose
+    value is legitimately null (``endpoint_url`` on plain S3) is kept
+    rather than being read as "deleted" and silently dropped.
     """
     merged = {}
     conflicts = []
     for key in set(base) | set(ours) | set(theirs):
-        o, a, b = base.get(key), ours.get(key), theirs.get(key)
+        o = base.get(key, _ABSENT)
+        a = ours.get(key, _ABSENT)
+        b = theirs.get(key, _ABSENT)
         if a == b:
             value = a
         elif a == o:
@@ -1767,9 +1874,16 @@ def _merge_maps(base, ours, theirs):
         else:
             conflicts.append(key)
             value = a
-        if value is not None:
+        if value is not _ABSENT:
             merged[key] = value
     return merged, sorted(conflicts)
+
+
+def _read_text_or_empty(path):
+    try:
+        return Path(path).read_text()
+    except OSError:
+        return ""
 
 
 def _read_manifest_for_merge(path):
@@ -1867,6 +1981,10 @@ def sparse(porcelain):
 
     profile = _sparse_profile(git_root)
     inside, outside = profile.partition(dict(s3lfs.manifest.get("files", {})))
+    # partition() can discover mid-flight that it cannot apply the rules,
+    # after _sparse_profile already had its chance to warn.
+    if profile.degraded_reason:
+        click.echo(f"Warning: {profile.degraded_reason}")
 
     if porcelain:
         for key in sorted(inside):
@@ -1912,7 +2030,15 @@ def merge_driver(base, ours, theirs, target):
     Writes the result over OURS, as git requires, and exits non-zero when
     a real conflict remains.
     """
-    if target and Path(target).name == ".gitignore":
+    # %P names the real path; without it (a stale driver config, or a
+    # hand-written .gitattributes) fall back to sniffing our side, so a
+    # .gitignore is never parsed as -- or overwritten by -- a manifest.
+    is_gitignore = (
+        Path(target).name == ".gitignore"
+        if target
+        else S3LFS_GITIGNORE_START in _read_text_or_empty(ours)
+    )
+    if is_gitignore:
         merged_text, conflict = _merge_gitignore(base, ours, theirs)
         Path(ours).write_text(merged_text)
         if conflict:
@@ -1929,7 +2055,15 @@ def merge_driver(base, ours, theirs, target):
         our_data = _read_manifest_for_merge(ours)
         their_data = _read_manifest_for_merge(theirs)
     except Exception as e:
-        click.echo(f"s3lfs: cannot merge manifest ({e}); falling back to git", err=True)
+        # Leave %A exactly as git supplied it (our side) and report a
+        # conflict. Git does not substitute its own merge for a failing
+        # driver, so saying it "falls back" would be a lie -- the user has
+        # to resolve this by hand.
+        click.echo(
+            f"s3lfs: cannot merge {target or 'manifest'} ({e}); "
+            "our version was left in place -- resolve it by hand.",
+            err=True,
+        )
         raise SystemExit(1)
 
     files, file_conflicts = _merge_maps(
@@ -2060,6 +2194,25 @@ def verify(revision, base, no_sign_request, use_acceleration, endpoint_url, work
         if files is None:
             click.echo(f"No manifest at revision {revision}; nothing to verify.")
             return
+        # Hashes come from that revision but the bucket and prefix come from
+        # the working tree. If the revision stored different ones, we would
+        # be looking in the wrong place and calling it missing.
+        stored = _manifest_config_at_revision(git_root, revision)
+        mismatch = [
+            f"{key}: {stored[key]!r} at {revision}, {current!r} here"
+            for key, current in (
+                ("bucket_name", s3lfs.bucket_name),
+                ("repo_prefix", s3lfs.repo_prefix),
+            )
+            if stored.get(key) is not None and stored.get(key) != current
+        ]
+        if mismatch:
+            click.echo(
+                f"Warning: {revision} was written against different S3 "
+                "settings, so this check may look in the wrong place:"
+            )
+            for line in mismatch:
+                click.echo(f"  {line}")
     else:
         files = dict(s3lfs.manifest.get("files", {}))
 
@@ -2139,10 +2292,26 @@ def pre_commit(no_sign_request, use_acceleration, endpoint_url):
         profile = _sparse_profile(git_root)
         s3lfs.track_modified_files_cached(silence=True, keys=profile.select(tracked))
 
-    subprocess.run(
-        ["git", "add", "--", manifest_path.name],
+    # Stage the manifest, and .gitignore alongside it: `track` writes both,
+    # and committing one without the other leaves the ignore rules and the
+    # tracked set out of step.
+    to_stage = [manifest_path.name]
+    if (git_root / ".gitignore").exists():
+        to_stage.append(".gitignore")
+
+    result = subprocess.run(
+        ["git", "add", "--", *to_stage],
+        capture_output=True,
+        text=True,
         cwd=str(git_root),
     )
+    if result.returncode != 0:
+        # Letting the commit proceed here would record the old hashes while
+        # the new content is already in S3 -- and pre-push compares against
+        # the tip, so it would not catch it either.
+        click.echo("Error: could not stage the s3lfs manifest:")
+        click.echo(result.stderr.strip())
+        raise SystemExit(1)
 
 
 cli.add_command(init)

--- a/s3lfs/config.py
+++ b/s3lfs/config.py
@@ -13,9 +13,16 @@ import yaml
 CONFIG_FILENAME = ".s3lfsconfig"
 
 # Keys recognised in .s3lfsconfig and their default values.
+#
+# endpoint_url and workers matter most for teams: without them here, every
+# developer on MinIO/R2 has to remember --endpoint-url on every command,
+# and putting it in this file used to be dropped silently, sending requests
+# to AWS instead.
 DEFAULTS = {
     "no_sign_request": False,
     "use_acceleration": False,
+    "endpoint_url": None,
+    "workers": None,
 }
 
 
@@ -28,15 +35,25 @@ def find_config(git_root):
 def load_config(git_root):
     """Load .s3lfsconfig from *git_root* and return a dict.
 
-    Missing file → empty dict.  Unknown keys are silently ignored so the
-    file stays forward-compatible.
+    Missing file → empty dict.
+
+    Unrecognised keys are reported rather than dropped in silence: a
+    misspelled or unsupported setting that changes where data goes is
+    exactly the kind of thing you want to hear about, not discover later.
     """
     path = find_config(git_root)
     if path is None:
         return {}
     with open(path, "r") as f:
         data = yaml.safe_load(f) or {}
-    # Only keep recognised keys
+
+    unknown = sorted(set(data) - set(DEFAULTS))
+    if unknown:
+        print(
+            f"Warning: ignoring unrecognised key(s) in {CONFIG_FILENAME}: "
+            + ", ".join(unknown)
+        )
+
     return {k: data[k] for k in DEFAULTS if k in data}
 
 

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -438,6 +438,32 @@ class S3LFS:
         """The S3 key a file's content is stored under."""
         return f"{self.repo_prefix}/assets/{file_hash}/{manifest_key}.gz"
 
+    def _list_keys(self, prefix):
+        """Every key under a prefix, following pagination.
+
+        A single list_objects_v2 call stops at 1000 keys. Deriving a chunk
+        count from a truncated listing rebuilds a short file and calls it a
+        success, which is worse than failing outright.
+        """
+        client = self._get_s3_client()
+        keys: list = []
+        token = None
+        while True:
+            kwargs = {"Bucket": self.bucket_name, "Prefix": prefix}
+            if token:
+                kwargs["ContinuationToken"] = token
+            resp = client.list_objects_v2(**kwargs)
+            contents = resp.get("Contents") or []
+            keys.extend(obj["Key"] for obj in contents)
+
+            # Continue only on a genuine continuation token. Testing
+            # IsTruncated for truthiness is not enough: any object that is
+            # not a bool -- a stub client, an unexpected response shape --
+            # reads as "more pages" and spins forever.
+            token = resp.get("NextContinuationToken")
+            if resp.get("IsTruncated") is not True or not isinstance(token, str):
+                return keys
+
     def _delete_asset(self, base_key):
         """Delete an asset and every chunk belonging to it.
 
@@ -445,8 +471,7 @@ class S3LFS:
         itself, so deleting only the base key leaves the whole file behind.
         """
         client = self._get_s3_client()
-        resp = client.list_objects_v2(Bucket=self.bucket_name, Prefix=base_key)
-        keys = [obj["Key"] for obj in resp.get("Contents", [])]
+        keys = self._list_keys(base_key)
         # Guard against a prefix match on an unrelated, longer key.
         keys = [k for k in keys if self._key_covered_by(k, {base_key})]
         if not keys:
@@ -630,12 +655,33 @@ class S3LFS:
     def load_manifest(self):
         """Load the local manifest (YAML or JSON format)."""
         if self.manifest_file.exists():
-            with open(self.manifest_file, "r") as f:
-                # Detect format based on extension
-                if self.manifest_file.suffix in [".yaml", ".yml"]:
-                    self.manifest = yaml_load(f) or {"files": {}}
-                else:
-                    self.manifest = json.load(f)
+            try:
+                with open(self.manifest_file, "r") as f:
+                    # Detect format based on extension
+                    if self.manifest_file.suffix in [".yaml", ".yml"]:
+                        self.manifest = yaml_load(f) or {"files": {}}
+                    else:
+                        self.manifest = json.load(f)
+            except (yaml.YAMLError, json.JSONDecodeError) as e:
+                # The likeliest cause by far is an unresolved merge, which a
+                # teammate who has not run 's3lfs install' will hit. A bare
+                # parser traceback does not tell them that.
+                hint = ""
+                if "<<<<<<<" in self.manifest_file.read_text(errors="replace"):
+                    hint = (
+                        " It contains merge conflict markers -- resolve the "
+                        "conflict, or run 's3lfs install' to register the "
+                        "merge driver that prevents it."
+                    )
+                raise RuntimeError(
+                    f"Cannot read manifest {self.manifest_file}: {e}.{hint}"
+                ) from e
+            if not isinstance(self.manifest, dict):
+                raise RuntimeError(
+                    f"Manifest {self.manifest_file} is not a mapping; "
+                    "it may have been overwritten."
+                )
+            self.manifest.setdefault("files", {})
         else:
             self.manifest = {"files": {}}  # Use file paths as keys
 
@@ -1045,18 +1091,33 @@ class S3LFS:
         :param expected: dict of manifest_key -> expected hash
         :param progress: show a progress bar while hashing
         :return: dict of manifest_key -> "up_to_date" | "modified" | "missing"
+        """
+        return {
+            key: (
+                "missing"
+                if h is None
+                else "up_to_date" if h == expected[key] else "modified"
+            )
+            for key, h in self.disk_hashes(expected, progress=progress).items()
+        }
+
+    def disk_hashes(self, keys, progress=False):
+        """Hash what is currently on disk for each manifest key.
+
+        :return: dict of manifest_key -> hash, or None where no file exists
 
         Uses the same load-cache-once, hash-on-miss strategy as
         track_modified_files_cached, so repeat calls over unchanged files
         cost a stat() each rather than a full re-read.
         """
+        expected = keys
         if not expected:
             return {}
 
         with self._lock_context():
             self.load_cache()
 
-        states = {}
+        hashes: dict = {}
         cache_updates = {}
 
         with tqdm(
@@ -1065,11 +1126,11 @@ class S3LFS:
             unit="file",
             disable=not progress,
         ) as pbar:
-            for manifest_key, expected_hash in expected.items():
+            for manifest_key in expected:
                 pbar.update(1)
                 filesystem_path = self.path_resolver.to_filesystem_path(manifest_key)
                 if not filesystem_path.exists():
-                    states[manifest_key] = "missing"
+                    hashes[manifest_key] = None
                     continue
 
                 stat = filesystem_path.stat()
@@ -1089,9 +1150,7 @@ class S3LFS:
                         "timestamp": time.time(),
                     }
 
-                states[manifest_key] = (
-                    "up_to_date" if current_hash == expected_hash else "modified"
-                )
+                hashes[manifest_key] = current_hash
 
         if cache_updates:
             with self._lock_context():
@@ -1099,7 +1158,7 @@ class S3LFS:
                 self._cache_dirty = True
                 self.save_cache()
 
-        return states
+        return hashes
 
     def track_modified_files_cached(self, silence=True, keys=None):
         """
@@ -2067,10 +2126,7 @@ class S3LFS:
         """Discover S3 chunks for a single file."""
         s3_key = f"{self.repo_prefix}/assets/{file_hash}/{manifest_key}.gz"
 
-        resp = self._get_s3_client().list_objects_v2(
-            Bucket=self.bucket_name, Prefix=f"{s3_key}.chunk"
-        )
-        chunk_keys = [ck["Key"] for ck in resp.get("Contents", [])]
+        chunk_keys = self._list_keys(f"{s3_key}.chunk")
 
         if chunk_keys:
             return [

--- a/specs/README.md
+++ b/specs/README.md
@@ -2,6 +2,9 @@
 
 Formal models of s3lfs's concurrency-sensitive protocols, checked with TLC.
 
+References below name functions rather than line numbers, which go stale as
+the code moves.
+
 ## Setup
 
 ```sh
@@ -11,10 +14,81 @@ curl -sSL -o tla2tools.jar \
 
 `tla2tools.jar` is not committed — add it to `.gitignore` if you keep it here.
 
+## S3lfsWorkingCopy — clobbering, aliasing, and dangling references
+
+Models the working-copy lifecycle -- `track`, `remove`, commit, branch switch,
+`sync` (download and prune), and `cleanup` -- against a user who edits tracked
+files without uploading them. The other specs model the storage layer; this one
+models the layer that decides which bytes on disk get replaced or deleted.
+
+Three invariants:
+
+- `NoDataLoss` — no automatic operation destroys content that exists only on
+  disk. A history variable records any content removed while stored nowhere.
+- `NoDanglingReference` — every manifest entry has an object behind it, so a
+  checkout cannot 404.
+- `NoCollateralDeletion` — distinct live paths occupy distinct storage keys, so
+  untracking or collecting one path never destroys bytes another path refers to.
+
+Two constants isolate the design decisions those properties rest on:
+
+```sh
+java -jar tla2tools.jar -config S3lfsWorkingCopy_Fixed.cfg            S3lfsWorkingCopy.tla  # current code
+java -jar tla2tools.jar -config S3lfsWorkingCopy_NoGuard.cfg          S3lfsWorkingCopy.tla  # violates NoDataLoss
+java -jar tla2tools.jar -config S3lfsWorkingCopy_ContentAddressed.cfg S3lfsWorkingCopy.tla  # violates NoCollateralDeletion
+java -jar tla2tools.jar -config S3lfsWorkingCopy_Large.cfg            S3lfsWorkingCopy.tla  # three content values
+```
+
+`CLOBBER_GUARD = FALSE` reproduces the defect fixed in #108: `sync` chose what to
+download from manifest hashes alone, so a file edited but not uploaded was
+replaced silently.
+
+`PATH_AWARE_KEYS = FALSE` reproduces content-only addressing, where two paths
+holding identical bytes share one object and untracking either destroys both.
+The real key function (`_asset_base_key`) includes the path, which is what makes
+the invariant hold.
+
+**This spec changed the code.** Checking the first version -- where the guard
+asked only whether a file still matched the hash the manifest recorded -- TLC
+produced this trace:
+
+```
+track p2  ->  commit  ->  remove p2  ->  cleanup  ->  sync
+```
+
+`remove` drops the manifest entry, `cleanup` collects the now-unreferenced
+object, and `sync` then prunes the local file because it still matches the
+recorded hash -- deleting the last copy. The guard was strengthened to the
+condition the model actually requires: **only take bytes off disk when those
+bytes can be fetched back from S3**. That is `_recoverable()` in `cli.py`, and
+`TestSyncNeverRemovesUnrecoverableContent` pins the trace as a regression test.
+
+## S3lfsOwnership — which system owns each file
+
+s3lfs keeps its files out of git by writing entries into a marked `.gitignore`
+block and removing them from the index, which makes ownership a shared, mutable
+thing between two systems. Two ways to get it wrong:
+
+- `NoDualOwnership` — a path is never tracked by git and s3lfs at once, which
+  would put the large file into git history anyway.
+- `NoOrphanedFile` — a file on disk that git ignores is tracked by s3lfs.
+  Otherwise it is invisible to both: git will not stage it, s3lfs will not
+  upload it, and it survives only on the machine that created it.
+
+```sh
+java -jar tla2tools.jar -config S3lfsOwnership_PerFile.cfg   S3lfsOwnership.tla  # current code
+java -jar tla2tools.jar -config S3lfsOwnership_Directory.cfg S3lfsOwnership.tla  # violates NoOrphanedFile
+```
+
+`IGNORE_SCOPE = "directory"` reproduces the defect fixed in #108, where tracking
+a directory wrote a single `/dir/` pattern: a source file added under that
+directory afterwards is hidden from git and absent from the manifest. The
+per-file expansion (`_gitignore_entries_for`) ignores exactly what s3lfs stores
+and nothing else.
+
 ## S3lfsGC — garbage collection vs. concurrent upload
 
-Models `cleanup_s3` (`s3lfs/core.py:1298-1346`) racing `parallel_upload_chunked`
-(`s3lfs/core.py:1456-1535`).
+Models `S3LFS.cleanup_s3` racing `S3LFS.parallel_upload_chunked`.
 
 The invariant `NoDanglingReference` states that every hash referenced by the
 manifest has a corresponding S3 object. Violating it means a `checkout` 404s on
@@ -92,9 +166,9 @@ independent knobs:
   saving. TRUE models `parallel_upload_chunked:1525`, `upload:1258`,
   `track_interleaved:2480`; FALSE models `remove_file:1284`,
   `remove_subtree:1776`, `track_modified_files_cached:830`,
-  `track_modified_files:1381`.
+  `S3LFS.track_modified_files`.
 - `SHARED_LOCK` — whether all processes agree on one lock file. FALSE models the
-  CWD-relative `temp_dir` defect at `core.py:158`.
+  CWD-relative `temp_dir` defect in `S3LFS.__init__`.
 
 `NoLostUpdate` compares the manifest against a ghost variable holding the result
 of an equivalent serial execution. A violation is one process erasing another's
@@ -137,20 +211,19 @@ system.
 
 ## S3lfsChunks — partial chunked upload and silent truncation
 
-Models `parallel_upload_chunked` (`s3lfs/core.py:1456-1535`) followed by the
-checkout that reassembles the file (`_discover_chunks_for_file:1565-1584`,
-`_finalize_file:1615-1637`).
+Models `S3LFS.parallel_upload_chunked` followed by the checkout that
+reassembles the file (`S3LFS._discover_chunks_for_file`,
+`S3LFS._finalize_file`).
 
 Three defects interact:
 
-1. The manifest entry is recorded at *prep* time (`core.py:1498`), before any
-   chunk is PUT.
-2. Per-chunk upload failures are caught, printed, and skipped
-   (`core.py:1513-1516`); the `finally` at `core.py:1524` writes the manifest
-   anyway.
-3. Checkout infers the chunk count from `len(chunk_keys)` and reads indices
-   `0..n-1` (`core.py:1584`), assuming the surviving chunks form a contiguous
-   prefix.
+1. The manifest entry is recorded at *prep* time, in `_prepare_file_for_upload`,
+   before any chunk is PUT.
+2. Per-chunk upload failures are caught, printed, and skipped; the `finally`
+   in `parallel_upload_chunked` writes the manifest anyway.
+3. Checkout infers the chunk count from `len(chunk_keys)` in
+   `_discover_chunks_for_file` and reads indices `0..n-1`, assuming the
+   surviving chunks form a contiguous prefix.
 
 `NoSilentCorruption` states that a checkout reporting success produced the whole
 file. `ManifestImpliesChunks` is the stronger upload-side property: a manifest
@@ -220,7 +293,7 @@ the same file.
 
 The model also carries the directory tree, because s3lfs's own metadata lives in
 the tree s3lfs enumerates. `_resolve_filesystem_paths` uses `rglob("*")` with no
-exclusion list (`core.py:1878`).
+exclusion list.
 
 ```
 R                 repository root, holds .s3_manifest.yaml
@@ -402,7 +475,7 @@ dimension. It therefore cannot see the mismatch between GC's reachability unit
 It also assumes manifest reads and writes are mutually exclusive — that the
 `portalocker` lock actually works. `S3lfsManifest` discharges exactly that
 assumption, and shows it does not currently hold: the lock is only real when
-`SHARED_LOCK` is TRUE, which the CWD-relative `temp_dir` at `s3lfs/core.py:158`
+`SHARED_LOCK` is TRUE, which the CWD-relative `temp_dir` in `S3LFS.__init__`
 does not guarantee. **The `INFLIGHT` result therefore depends on fixing the lock
 path first.** Resolve the lock file relative to the git root, as the manifest
 path already is.

--- a/specs/S3lfsOwnership.tla
+++ b/specs/S3lfsOwnership.tla
@@ -1,0 +1,134 @@
+-------------------------- MODULE S3lfsOwnership --------------------------
+(***************************************************************************)
+(* Models which system owns each file: git, s3lfs, or neither.             *)
+(*                                                                         *)
+(* s3lfs keeps its files out of git by writing entries into a marked block *)
+(* in .gitignore and removing them from the index.  That makes ownership a *)
+(* shared, mutable thing between two systems, and there are two ways to    *)
+(* get it wrong:                                                           *)
+(*                                                                         *)
+(*   NoDualOwnership   a path is never tracked by git and s3lfs at once.   *)
+(*                     Both would version the same bytes, and the large    *)
+(*                     file would enter git history -- the outcome s3lfs   *)
+(*                     exists to prevent.                                  *)
+(*                                                                         *)
+(*   NoOrphanedFile    a file on disk that git ignores is tracked by       *)
+(*                     s3lfs.  Otherwise it is invisible to both: git will *)
+(*                     not stage it and s3lfs will not upload it, so it    *)
+(*                     exists on one machine and is lost on a fresh clone. *)
+(*                                                                         *)
+(* IGNORE_SCOPE isolates the decision that NoOrphanedFile rests on:        *)
+(*                                                                         *)
+(*   "perFile"    -- tracking expands to one .gitignore entry per tracked  *)
+(*                   file (_gitignore_entries_for)                         *)
+(*   "directory"  -- tracking a directory writes a single `/dir/` pattern, *)
+(*                   which is what the code did before #108                *)
+(***************************************************************************)
+EXTENDS FiniteSets
+
+CONSTANTS
+    Files,          \* every path that could exist, e.g. {a1, a2}
+    IGNORE_SCOPE    \* "perFile" or "directory"
+
+VARIABLES
+    onDisk,         \* files that exist in the working tree
+    manifest,       \* files s3lfs tracks
+    gitIndex,       \* files git tracks
+    ignoreEntries   \* entries in the s3lfs .gitignore block
+
+vars == <<onDisk, manifest, gitIndex, ignoreEntries>>
+
+(***************************************************************************)
+(* Every file here lives in one directory, which is the case that matters: *)
+(* a single `/dir/` pattern covers all of them, a per-file expansion       *)
+(* covers only the ones actually tracked.                                  *)
+(***************************************************************************)
+DirPattern == "dir"
+
+\* Which files a set of .gitignore entries actually hides.
+Ignored(entries) ==
+    IF DirPattern \in entries
+        THEN Files                          \* `/dir/` hides everything under it
+        ELSE {f \in Files : f \in entries}   \* a literal entry hides one file
+
+\* What tracking a file adds to the block.
+EntriesFor(f) ==
+    IF IGNORE_SCOPE = "directory" THEN {DirPattern} ELSE {f}
+
+TypeOK ==
+    /\ onDisk        \subseteq Files
+    /\ manifest      \subseteq Files
+    /\ gitIndex      \subseteq Files
+    /\ ignoreEntries \subseteq Files \cup {DirPattern}
+
+Init ==
+    /\ onDisk = {}
+    /\ manifest = {}
+    /\ gitIndex = {}
+    /\ ignoreEntries = {}
+
+(***************************************************************************)
+(* The user                                                                *)
+(***************************************************************************)
+
+\* Create a file: a new asset, or a source file a teammate adds later.
+Create ==
+    /\ \E f \in Files :
+        /\ f \notin onDisk
+        /\ onDisk' = onDisk \cup {f}
+    /\ UNCHANGED <<manifest, gitIndex, ignoreEntries>>
+
+\* `git add`.  Git refuses paths its ignore rules cover, which is the whole
+\* mechanism s3lfs relies on to keep large files out of history.
+GitAdd ==
+    /\ \E f \in Files :
+        /\ f \in onDisk
+        /\ f \notin Ignored(ignoreEntries)
+        /\ gitIndex' = gitIndex \cup {f}
+    /\ UNCHANGED <<onDisk, manifest, ignoreEntries>>
+
+GitRemove ==
+    /\ \E f \in gitIndex : gitIndex' = gitIndex \ {f}
+    /\ UNCHANGED <<onDisk, manifest, ignoreEntries>>
+
+(***************************************************************************)
+(* s3lfs track: upload, record, ignore, and de-index.                      *)
+(*                                                                         *)
+(* The de-index step matters because .gitignore has no effect on files git *)
+(* already tracks -- without it git keeps versioning the large file        *)
+(* alongside S3.                                                           *)
+(***************************************************************************)
+Track ==
+    /\ \E f \in Files :
+        /\ f \in onDisk
+        /\ f \notin manifest
+        /\ manifest' = manifest \cup {f}
+        /\ ignoreEntries' = ignoreEntries \cup EntriesFor(f)
+        /\ gitIndex' = gitIndex \ {f}
+    /\ UNCHANGED onDisk
+
+\* s3lfs remove: stop tracking, and stop ignoring.
+Untrack ==
+    /\ \E f \in manifest :
+        /\ manifest' = manifest \ {f}
+        /\ ignoreEntries' = ignoreEntries \ EntriesFor(f)
+        /\ UNCHANGED <<onDisk, gitIndex>>
+
+Next == Create \/ GitAdd \/ GitRemove \/ Track \/ Untrack
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* Properties                                                              *)
+(***************************************************************************)
+
+\* Never versioned by both systems at once.
+NoDualOwnership == manifest \cap gitIndex = {}
+
+\* A file hidden from git is tracked by s3lfs.  A file hidden from git and
+\* absent from the manifest is owned by nobody: it exists on one disk and
+\* disappears on the next clone.
+NoOrphanedFile ==
+    \A f \in onDisk : f \in Ignored(ignoreEntries) => f \in manifest
+
+=============================================================================

--- a/specs/S3lfsOwnership_Directory.cfg
+++ b/specs/S3lfsOwnership_Directory.cfg
@@ -1,0 +1,15 @@
+\* Tracking a directory wrote a single `/dir/` pattern (the defect fixed in
+\* #108).  Expected to violate NoOrphanedFile: a file added under the
+\* directory afterwards is hidden from git and absent from the manifest.
+SPECIFICATION Spec
+
+CONSTANTS
+    Files = {a1, a2}
+    IGNORE_SCOPE = "directory"
+
+INVARIANT
+    TypeOK
+    NoDualOwnership
+    NoOrphanedFile
+
+CHECK_DEADLOCK FALSE

--- a/specs/S3lfsOwnership_PerFile.cfg
+++ b/specs/S3lfsOwnership_PerFile.cfg
@@ -1,0 +1,13 @@
+\* Current code: tracking expands to one .gitignore entry per tracked file.
+SPECIFICATION Spec
+
+CONSTANTS
+    Files = {a1, a2}
+    IGNORE_SCOPE = "perFile"
+
+INVARIANT
+    TypeOK
+    NoDualOwnership
+    NoOrphanedFile
+
+CHECK_DEADLOCK FALSE

--- a/specs/S3lfsWorkingCopy.tla
+++ b/specs/S3lfsWorkingCopy.tla
@@ -1,0 +1,227 @@
+------------------------- MODULE S3lfsWorkingCopy -------------------------
+(***************************************************************************)
+(* Models the working-copy lifecycle: track, remove, branch switch, sync,  *)
+(* and garbage collection, against a hostile user who edits tracked files  *)
+(* without uploading them.                                                 *)
+(*                                                                         *)
+(* The existing specs model the storage layer.  This one models the layer  *)
+(* above it -- the one that decides which bytes on disk get replaced or    *)
+(* deleted -- and checks three things a large-asset store must never get   *)
+(* wrong:                                                                  *)
+(*                                                                         *)
+(*   NoDataLoss             content that exists only on disk is never      *)
+(*                          destroyed by an automatic operation            *)
+(*   NoDanglingReference    every manifest entry has an object behind it   *)
+(*   NoCollateralDeletion   untracking one path never destroys the bytes   *)
+(*                          another path still refers to                   *)
+(*                                                                         *)
+(* Two constants isolate the design decisions those properties depend on,  *)
+(* so TLC can show each one is load-bearing rather than incidental:        *)
+(*                                                                         *)
+(*   CLOBBER_GUARD    TRUE  -- sync refuses to replace or delete on-disk    *)
+(*                             content that differs from what the manifest *)
+(*                             recorded (S3LFS.compare_to_hashes drives    *)
+(*                             this in `sync`)                             *)
+(*                    FALSE -- sync replaces whatever is in the way, which *)
+(*                             is what the code did before this was fixed  *)
+(*                                                                         *)
+(*   PATH_AWARE_KEYS  TRUE  -- an object's key is derived from path AND    *)
+(*                             content hash (_asset_base_key)              *)
+(*                    FALSE -- keyed by content hash alone, so two paths   *)
+(*                             holding identical bytes share one object    *)
+(***************************************************************************)
+EXTENDS FiniteSets, Naturals
+
+CONSTANTS
+    Paths,            \* tracked path names, e.g. {p1, p2}
+    Contents,         \* content values; a content is its own hash here
+    Absent,           \* marker for "no file on disk" / "no manifest entry"
+    CLOBBER_GUARD,
+    PATH_AWARE_KEYS
+
+VARIABLES
+    disk,             \* Paths -> Contents \cup {Absent}
+    manifest,         \* Paths -> Contents \cup {Absent}: the working manifest
+    baseline,         \* Paths -> Contents \cup {Absent}: manifest at the
+                      \* revision sync diffs against (the previous HEAD)
+    s3,               \* set of storage keys currently present
+    lost              \* history: contents destroyed while stored nowhere
+
+vars == <<disk, manifest, baseline, s3, lost>>
+
+ASSUME Absent \notin Contents
+
+Values == Contents \cup {Absent}
+
+(***************************************************************************)
+(* Storage keys.  With PATH_AWARE_KEYS the key carries the path, so the    *)
+(* same bytes tracked at two paths occupy two objects and removing one     *)
+(* cannot affect the other.  Without it, identical content aliases.        *)
+(***************************************************************************)
+Key(p, c) == IF PATH_AWARE_KEYS THEN <<p, c>> ELSE <<"shared", c>>
+
+\* Keys reachable from the manifest: what garbage collection must keep.
+LiveKeys == {Key(p, manifest[p]) : p \in {q \in Paths : manifest[q] # Absent}}
+
+Stored(p, c) == c # Absent /\ Key(p, c) \in s3
+
+\* Content that exists on disk and nowhere else is irreplaceable: if an
+\* operation removes it from disk, it is gone for good.
+Irreplaceable(p) == disk[p] # Absent /\ ~Stored(p, disk[p])
+
+\* Record destruction of whatever p currently holds, if it was the only copy.
+Destroyed(p) == IF Irreplaceable(p) THEN {disk[p]} ELSE {}
+
+TypeOK ==
+    /\ disk     \in [Paths -> Values]
+    /\ manifest \in [Paths -> Values]
+    /\ baseline \in [Paths -> Values]
+    /\ s3       \subseteq ({"shared"} \cup Paths) \X Contents
+    /\ lost     \subseteq Contents
+
+Init ==
+    /\ disk     = [p \in Paths |-> Absent]
+    /\ manifest = [p \in Paths |-> Absent]
+    /\ baseline = [p \in Paths |-> Absent]
+    /\ s3       = {}
+    /\ lost     = {}
+
+(***************************************************************************)
+(* The user                                                                *)
+(***************************************************************************)
+
+\* Create or edit a file without tracking it.  This is the state that makes
+\* clobbering possible: the bytes exist only here.  Tracked files are
+\* gitignored, so git cannot warn about this either.
+Edit ==
+    /\ \E p \in Paths, c \in Contents :
+        /\ disk[p] # c
+        /\ disk' = [disk EXCEPT ![p] = c]
+    /\ UNCHANGED <<manifest, baseline, s3, lost>>
+
+\* Delete a file yourself.  Deliberate, so it does not count as loss.
+UserDelete ==
+    /\ \E p \in Paths :
+        /\ disk[p] # Absent
+        /\ disk' = [disk EXCEPT ![p] = Absent]
+    /\ UNCHANGED <<manifest, baseline, s3, lost>>
+
+(***************************************************************************)
+(* s3lfs track: upload the bytes, then record them.                        *)
+(*                                                                         *)
+(* The object is PUT before the manifest names it, which is what keeps     *)
+(* NoDanglingReference true at every intermediate state.                   *)
+(***************************************************************************)
+Track ==
+    /\ \E p \in Paths :
+        /\ disk[p] # Absent
+        /\ manifest[p] # disk[p]
+        /\ s3' = s3 \cup {Key(p, disk[p])}
+        /\ manifest' = [manifest EXCEPT ![p] = disk[p]]
+    /\ UNCHANGED <<disk, baseline, lost>>
+
+\* s3lfs remove: drop the manifest entry.  The object stays until cleanup.
+Untrack ==
+    /\ \E p \in Paths :
+        /\ manifest[p] # Absent
+        /\ manifest' = [manifest EXCEPT ![p] = Absent]
+    /\ UNCHANGED <<disk, baseline, s3, lost>>
+
+(***************************************************************************)
+(* Committing and switching branches                                       *)
+(*                                                                         *)
+(* Commit makes the working manifest the baseline sync will diff against.  *)
+(* SwitchBranch moves the working manifest to some other committed state   *)
+(* while leaving the baseline at the old one -- exactly the situation      *)
+(* post-checkout hands to `s3lfs sync --from $1`.                          *)
+(***************************************************************************)
+Commit ==
+    /\ baseline' = manifest
+    /\ UNCHANGED <<disk, manifest, s3, lost>>
+
+SwitchBranch ==
+    /\ \E m \in [Paths -> Values] :
+        \* Only to a manifest whose entries are actually stored: a branch
+        \* referring to content nobody uploaded is the separate failure
+        \* NoDanglingReference already covers.
+        /\ \A p \in Paths : m[p] # Absent => Key(p, m[p]) \in s3
+        /\ manifest' = m
+    /\ UNCHANGED <<disk, baseline, s3, lost>>
+
+(***************************************************************************)
+(* s3lfs sync                                                              *)
+(*                                                                         *)
+(* Download: an entry whose manifest hash differs from what is on disk.    *)
+(* With the guard, a file is only replaced when what it holds is the       *)
+(* content the baseline recorded -- i.e. it is clean, so replacing it      *)
+(* loses nothing.  Without the guard, anything in the way is replaced.     *)
+(***************************************************************************)
+(***************************************************************************)
+(* The guard.  Matching a recorded hash is NOT sufficient: the object      *)
+(* behind that hash may since have been garbage-collected, in which case   *)
+(* the copy on disk is the last one.  TLC found exactly that trace --      *)
+(* track, commit, remove, cleanup, sync -- against the weaker rule.  The   *)
+(* condition that actually holds is: only take bytes off disk when those   *)
+(* bytes can be fetched back.                                              *)
+(***************************************************************************)
+SafeToReplace(p) ==
+    \/ disk[p] = Absent            \* nothing to lose
+    \/ Stored(p, disk[p])          \* retrievable, so removing it loses nothing
+
+SyncDownload ==
+    /\ \E p \in Paths :
+        /\ manifest[p] # Absent
+        /\ disk[p] # manifest[p]
+        /\ CLOBBER_GUARD => SafeToReplace(p)
+        /\ disk' = [disk EXCEPT ![p] = manifest[p]]
+        /\ lost' = lost \cup Destroyed(p)
+    /\ UNCHANGED <<manifest, baseline, s3>>
+
+\* Prune: a path the manifest no longer lists is removed from disk.
+SyncPrune ==
+    /\ \E p \in Paths :
+        /\ manifest[p] = Absent
+        /\ disk[p] # Absent
+        /\ CLOBBER_GUARD => SafeToReplace(p)
+        /\ disk' = [disk EXCEPT ![p] = Absent]
+        /\ lost' = lost \cup Destroyed(p)
+    /\ UNCHANGED <<manifest, baseline, s3>>
+
+(***************************************************************************)
+(* s3lfs cleanup: delete every object the manifest does not reach.         *)
+(*                                                                         *)
+(* Reachability is computed on the same key function the writer uses, so   *)
+(* whether this is safe depends entirely on PATH_AWARE_KEYS.               *)
+(***************************************************************************)
+Cleanup ==
+    /\ s3' = s3 \cap LiveKeys
+    /\ UNCHANGED <<disk, manifest, baseline, lost>>
+
+Next ==
+    \/ Edit \/ UserDelete
+    \/ Track \/ Untrack
+    \/ Commit \/ SwitchBranch
+    \/ SyncDownload \/ SyncPrune
+    \/ Cleanup
+
+Spec == Init /\ [][Next]_vars
+
+(***************************************************************************)
+(* Properties                                                              *)
+(***************************************************************************)
+
+\* No automatic operation destroyed the only copy of anything.
+NoDataLoss == lost = {}
+
+\* Every manifest entry has an object behind it, so checkout cannot 404.
+NoDanglingReference ==
+    \A p \in Paths : manifest[p] # Absent => Key(p, manifest[p]) \in s3
+
+\* Untracking or cleaning up on one path never removes the bytes another
+\* path still refers to.  Distinct live paths must occupy distinct keys.
+NoCollateralDeletion ==
+    \A p, q \in Paths :
+        (p # q /\ manifest[p] # Absent /\ manifest[q] # Absent)
+            => (Key(p, manifest[p]) # Key(q, manifest[q]))
+
+=============================================================================

--- a/specs/S3lfsWorkingCopy_ContentAddressed.cfg
+++ b/specs/S3lfsWorkingCopy_ContentAddressed.cfg
@@ -1,0 +1,18 @@
+\* Keys derived from content alone, so identical bytes at two paths alias.
+\* Expected to violate NoCollateralDeletion and NoDanglingReference.
+SPECIFICATION Spec
+
+CONSTANTS
+    Paths = {p1, p2}
+    Contents = {c1, c2}
+    Absent = absent
+    CLOBBER_GUARD = TRUE
+    PATH_AWARE_KEYS = FALSE
+
+INVARIANT
+    TypeOK
+    NoDataLoss
+    NoDanglingReference
+    NoCollateralDeletion
+
+CHECK_DEADLOCK FALSE

--- a/specs/S3lfsWorkingCopy_Fixed.cfg
+++ b/specs/S3lfsWorkingCopy_Fixed.cfg
@@ -1,0 +1,17 @@
+\* Current code: sync guards against clobbering, keys carry the path.
+SPECIFICATION Spec
+
+CONSTANTS
+    Paths = {p1, p2}
+    Contents = {c1, c2}
+    Absent = absent
+    CLOBBER_GUARD = TRUE
+    PATH_AWARE_KEYS = TRUE
+
+INVARIANT
+    TypeOK
+    NoDataLoss
+    NoDanglingReference
+    NoCollateralDeletion
+
+CHECK_DEADLOCK FALSE

--- a/specs/S3lfsWorkingCopy_Large.cfg
+++ b/specs/S3lfsWorkingCopy_Large.cfg
@@ -1,0 +1,19 @@
+\* Same properties over a larger state space: three content values.
+\* Path count stays at two: SwitchBranch ranges over every possible branch
+\* manifest, so a third path multiplies the state space by ~16.
+SPECIFICATION Spec
+
+CONSTANTS
+    Paths = {p1, p2}
+    Contents = {c1, c2, c3}
+    Absent = absent
+    CLOBBER_GUARD = TRUE
+    PATH_AWARE_KEYS = TRUE
+
+INVARIANT
+    TypeOK
+    NoDataLoss
+    NoDanglingReference
+    NoCollateralDeletion
+
+CHECK_DEADLOCK FALSE

--- a/specs/S3lfsWorkingCopy_NoGuard.cfg
+++ b/specs/S3lfsWorkingCopy_NoGuard.cfg
@@ -1,0 +1,18 @@
+\* sync without the clobber guard: the defect fixed in #108.
+\* Expected to violate NoDataLoss.
+SPECIFICATION Spec
+
+CONSTANTS
+    Paths = {p1, p2}
+    Contents = {c1, c2}
+    Absent = absent
+    CLOBBER_GUARD = FALSE
+    PATH_AWARE_KEYS = TRUE
+
+INVARIANT
+    TypeOK
+    NoDataLoss
+    NoDanglingReference
+    NoCollateralDeletion
+
+CHECK_DEADLOCK FALSE

--- a/specs/check.sh
+++ b/specs/check.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# Run the TLA+ models whose expected outcome is known, and fail if any of
+# them disagrees.
+#
+# Both outcomes matter. A model that should hold must hold; a model of a
+# known defect must still violate its invariant, otherwise the property is
+# vacuous and proves nothing about the code.
+#
+# Usage: specs/check.sh   (downloads tla2tools.jar if absent)
+
+set -eu
+
+cd "$(dirname "$0")"
+
+if [ ! -f tla2tools.jar ]; then
+    echo "Downloading tla2tools.jar..."
+    curl -sSL -o tla2tools.jar \
+        https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar
+fi
+
+run() {
+    java -XX:+UseParallelGC -cp tla2tools.jar tlc2.TLC \
+        -config "$2.cfg" -workers auto "$1.tla" 2>&1
+}
+
+failures=0
+
+# Configurations that must pass: module, config
+for pair in \
+    "S3lfsWorkingCopy S3lfsWorkingCopy_Fixed" \
+    "S3lfsWorkingCopy S3lfsWorkingCopy_Large" \
+    "S3lfsOwnership   S3lfsOwnership_PerFile"
+do
+    # shellcheck disable=SC2086
+    set -- $pair
+    printf '%-34s ' "$2 (expect: holds)"
+    if run "$1" "$2" | grep -q "No error has been found"; then
+        echo "ok"
+    else
+        echo "FAILED -- an invariant that should hold does not"
+        failures=$((failures + 1))
+    fi
+done
+
+# Configurations modelling a known defect: module, config, invariant
+for triple in \
+    "S3lfsWorkingCopy S3lfsWorkingCopy_NoGuard          NoDataLoss" \
+    "S3lfsWorkingCopy S3lfsWorkingCopy_ContentAddressed NoCollateralDeletion" \
+    "S3lfsOwnership   S3lfsOwnership_Directory          NoOrphanedFile"
+do
+    # shellcheck disable=SC2086
+    set -- $triple
+    printf '%-34s ' "$2 (expect: $3 fails)"
+    if run "$1" "$2" | grep -q "Error: Invariant $3 is violated"; then
+        echo "ok"
+    else
+        echo "FAILED -- the modelled defect no longer violates $3, so the"
+        echo "   property is vacuous and proves nothing about the code"
+        failures=$((failures + 1))
+    fi
+done
+
+if [ "$failures" -ne 0 ]; then
+    echo "$failures model check(s) disagreed with expectations"
+    exit 1
+fi
+
+echo "All model checks agree with expectations."

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -289,3 +289,32 @@ class TestConfigCLIIntegration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestConfigKeysTeamsNeed(unittest.TestCase):
+    """endpoint_url and workers used to be dropped silently, so a team on
+    MinIO/R2 that set them in .s3lfsconfig had every request go to AWS."""
+
+    def setUp(self):
+        self.temp_dir = Path(tempfile.mkdtemp())
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_endpoint_url_and_workers_are_loaded(self):
+        (self.temp_dir / ".s3lfsconfig").write_text(
+            "endpoint_url: http://minio.internal:9000\nworkers: 4\n"
+        )
+        config = load_config(self.temp_dir)
+        self.assertEqual(config["endpoint_url"], "http://minio.internal:9000")
+        self.assertEqual(config["workers"], 4)
+
+    def test_unknown_keys_are_reported(self):
+        (self.temp_dir / ".s3lfsconfig").write_text("endpint_url: typo\n")
+        with patch("builtins.print") as mock_print:
+            config = load_config(self.temp_dir)
+        self.assertEqual(config, {})
+        self.assertTrue(
+            any("endpint_url" in str(c) for c in mock_print.call_args_list),
+            "a misspelled key that changes where data goes was ignored silently",
+        )

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -464,7 +464,7 @@ class TestSyncCommand(GitRepoTestCase):
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertEqual(Path("data/a.bin").read_text(), "PRECIOUS UNSAVED WORK")
-        self.assertIn("locally modified", result.output)
+        self.assertIn("not in S3", result.output)
 
     def test_sync_force_overwrites_locally_modified_file(self):
         self._track_and_commit("data/a.bin", "v1", "track v1")
@@ -527,7 +527,7 @@ class TestSyncCommand(GitRepoTestCase):
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertTrue(Path("data/a.bin").exists())
         self.assertEqual(Path("data/a.bin").read_text(), "local edits worth keeping")
-        self.assertIn("local modifications", result.output)
+        self.assertIn("not in S3", result.output)
 
     def test_sync_no_prune_keeps_dropped_files(self):
         self._track_and_commit("data/a.bin", "a", "track a")
@@ -946,3 +946,197 @@ class TestCloneCommand(GitRepoTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestHooksDirResolution(GitRepoTestCase):
+    """Hooks must be found via git, not by assuming .git is a directory."""
+
+    def test_install_works_in_a_linked_worktree(self):
+        """In a linked worktree .git is a *file*, so guessing
+        git_root/.git/hooks fails with NotADirectoryError."""
+        self._commit_all("initial")
+        worktree = Path(self.temp_dir).parent / "s3lfs-wt"
+        self.addCleanup(shutil.rmtree, worktree, ignore_errors=True)
+        made = self._git("worktree", "add", "-q", str(worktree))
+        self.assertEqual(made.returncode, 0, msg=made.stdout + made.stderr)
+
+        os.chdir(worktree)
+        try:
+            self.assertTrue((worktree / ".git").is_file())
+            result = self.runner.invoke(cli, ["install"])
+            self.assertEqual(result.exit_code, 0, msg=result.output)
+            self.assertNotIn("Traceback", result.output)
+        finally:
+            os.chdir(self.temp_dir)
+
+
+class TestSyncOnBranchWithoutManifest(GitRepoTestCase):
+    def test_reports_instead_of_failing(self):
+        """Checking out a branch from before s3lfs is normal; the
+        post-checkout hook must not report an error for it."""
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+
+        self._git("checkout", "-q", "-b", "pre-s3lfs")
+        self._git("rm", "-q", ".s3_manifest.yaml")
+        self._git("commit", "-qm", "before s3lfs")
+
+        result = self.runner.invoke(cli, ["sync", "--from", "HEAD~1"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("nothing to sync", result.output)
+
+
+class TestRevisionManifestRobustness(GitRepoTestCase):
+    def test_unparseable_baseline_is_treated_as_no_baseline(self):
+        """A manifest committed with conflict markers -- what a teammate
+        without the merge driver produces -- must not raise a traceback out
+        of a post-checkout hook."""
+        good = Path(".s3_manifest.yaml").read_text()
+        Path(".s3_manifest.yaml").write_text(
+            "<<<<<<< HEAD\nfiles: {}\n=======\nfiles: {}\n>>>>>>> other\n"
+        )
+        self._git("add", "-f", ".s3_manifest.yaml")
+        self._git("commit", "-qm", "conflicted manifest")
+        # Working tree is fine again; only the committed baseline is broken.
+        Path(".s3_manifest.yaml").write_text(good)
+
+        result = self.runner.invoke(cli, ["sync", "--from", "HEAD"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertNotIn("Traceback", result.output)
+
+    def test_conflicted_working_manifest_explains_itself(self):
+        """A bare YAML traceback does not tell the user what to do."""
+        Path(".s3_manifest.yaml").write_text(
+            "<<<<<<< HEAD\nfiles: {}\n=======\nfiles: {}\n>>>>>>> other\n"
+        )
+        result = self.runner.invoke(cli, ["status"])
+
+        self.assertNotEqual(result.exit_code, 0)
+        message = str(result.exception) if result.exception else result.output
+        self.assertIn("merge conflict markers", message)
+        self.assertIn("s3lfs install", message)
+
+
+class TestPreCommitStaging(GitRepoTestCase):
+    def test_stages_gitignore_alongside_the_manifest(self):
+        """track writes both; committing one without the other leaves the
+        ignore rules and the tracked set out of step."""
+        self._commit_all("initial")
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+
+        result = self.runner.invoke(cli, ["pre-commit"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        staged = self._git("diff", "--cached", "--name-only").stdout.split()
+        self.assertIn(".s3_manifest.yaml", staged)
+        self.assertIn(".gitignore", staged)
+
+
+class TestMergeDriverRobustness(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = Path(os.path.realpath(tempfile.mkdtemp()))
+        self.runner = CliRunner()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _write(self, name, text):
+        path = self.temp_dir / name
+        path.write_text(text)
+        return path
+
+    def test_null_valued_key_is_not_dropped(self):
+        """Absence and a null value are different things."""
+        doc = "bucket_name: b\nrepo_prefix: p\nendpoint_url: null\nfiles: {}\n"
+        base = self._write("base.yaml", doc)
+        ours = self._write("ours.yaml", doc.replace("files: {}", "files:\n  a: h1"))
+        theirs = self._write("theirs.yaml", doc.replace("files: {}", "files:\n  b: h2"))
+
+        result = self.runner.invoke(
+            cli, ["merge-driver", str(base), str(ours), str(theirs), "m.yaml"]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        merged = yaml.safe_load(ours.read_text())
+        self.assertIn("endpoint_url", merged)
+        self.assertIsNone(merged["endpoint_url"])
+
+    def test_gitignore_detected_without_the_path_argument(self):
+        """A stale driver config may not pass %P; a .gitignore must not be
+        parsed as -- or overwritten by -- a manifest."""
+
+        def block(*entries):
+            lines = [S3LFS_GITIGNORE_START, *entries, S3LFS_GITIGNORE_END]
+            return "\n".join(lines) + "\n"
+
+        base = self._write("base.gi", block("/a.bin"))
+        ours = self._write("ours.gi", block("/a.bin", "/ours.bin"))
+        theirs = self._write("theirs.gi", block("/a.bin", "/theirs.bin"))
+
+        result = self.runner.invoke(
+            cli, ["merge-driver", str(base), str(ours), str(theirs)]
+        )
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        merged = ours.read_text()
+        self.assertIn("/ours.bin", merged)
+        self.assertIn("/theirs.bin", merged)
+        self.assertIn(S3LFS_GITIGNORE_START, merged)
+
+    def test_unmergeable_input_does_not_claim_git_falls_back(self):
+        base = self._write("base.yaml", "not: [a, manifest\n")
+        ours = self._write("ours.yaml", "files: {}\n")
+        theirs = self._write("theirs.yaml", "files: {}\n")
+
+        result = self.runner.invoke(
+            cli, ["merge-driver", str(base), str(ours), str(theirs), "m.yaml"]
+        )
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertNotIn("falling back to git", result.output)
+        self.assertIn("resolve it by hand", result.output)
+
+
+class TestSyncNeverRemovesUnrecoverableContent(GitRepoTestCase):
+    """The rule verified in specs/S3lfsWorkingCopy.tla: only take bytes off
+    disk when those bytes can be fetched back from S3.
+
+    Matching the hash the manifest recorded is not enough -- the object
+    behind that hash may since have been garbage-collected, making the copy
+    on disk the last one. TLC found this trace against the weaker rule.
+    """
+
+    def test_prune_keeps_a_file_whose_object_was_collected(self):
+        # track -> commit -> remove -> cleanup -> sync
+        self._write("data/a.bin", "the only copy")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+
+        self.runner.invoke(cli, ["remove", "data/a.bin"])
+        self._commit_all("untrack a")
+        cleanup = self.runner.invoke(cli, ["cleanup", "--force"])
+        self.assertEqual(cleanup.exit_code, 0, msg=cleanup.output)
+
+        result = self.runner.invoke(cli, ["sync", "--from", "HEAD~1"])
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertTrue(
+            Path("data/a.bin").exists(),
+            "sync deleted the last copy of content that is no longer in S3",
+        )
+        self.assertEqual(Path("data/a.bin").read_text(), "the only copy")
+        self.assertIn("not in S3", result.output)
+
+    def test_force_still_removes_it(self):
+        self._write("data/a.bin", "the only copy")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+        self.runner.invoke(cli, ["remove", "data/a.bin"])
+        self._commit_all("untrack a")
+        self.runner.invoke(cli, ["cleanup", "--force"])
+
+        result = self.runner.invoke(cli, ["sync", "--from", "HEAD~1", "--force"])
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertFalse(Path("data/a.bin").exists())

--- a/tests/test_s3lfs.py
+++ b/tests/test_s3lfs.py
@@ -3612,3 +3612,50 @@ class TestS3LFS(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestChunkListingPagination(unittest.TestCase):
+    """A single list_objects_v2 call stops at 1000 keys. Deriving a chunk
+    count from a truncated listing rebuilds a short file and reports
+    success, so the listing must follow continuation tokens."""
+
+    def test_list_keys_follows_continuation_tokens(self):
+        from unittest.mock import MagicMock
+
+        s3lfs = S3LFS.__new__(S3LFS)
+        s3lfs.bucket_name = "b"
+        client = MagicMock()
+        client.list_objects_v2.side_effect = [
+            {
+                "Contents": [{"Key": f"k{i}"} for i in range(1000)],
+                "IsTruncated": True,
+                "NextContinuationToken": "tok",
+            },
+            {"Contents": [{"Key": "k1000"}], "IsTruncated": False},
+        ]
+        s3lfs._get_s3_client = lambda: client
+
+        keys = s3lfs._list_keys("prefix")
+
+        self.assertEqual(len(keys), 1001)
+        self.assertIn("k1000", keys)
+        self.assertEqual(client.list_objects_v2.call_count, 2)
+        second = client.list_objects_v2.call_args_list[1].kwargs
+        self.assertEqual(second["ContinuationToken"], "tok")
+
+    def test_stops_on_a_response_that_is_not_a_real_page(self):
+        """Only a genuine continuation token continues the loop.
+
+        Testing IsTruncated for truthiness is not enough: a stub client or
+        an unexpected response shape makes every field truthy, which reads
+        as "more pages" forever. This hung the test suite once.
+        """
+        from unittest.mock import MagicMock
+
+        s3lfs = S3LFS.__new__(S3LFS)
+        s3lfs.bucket_name = "b"
+        client = MagicMock()
+        s3lfs._get_s3_client = lambda: client
+
+        self.assertEqual(s3lfs._list_keys("prefix"), [])
+        self.assertEqual(client.list_objects_v2.call_count, 1)

--- a/tests/test_sparse.py
+++ b/tests/test_sparse.py
@@ -143,11 +143,14 @@ class TestSparseProfileDetection(SparseRepoTestCase):
         self._enable_sparse("keep")
 
         profile = SparseProfile.detect(Path(self.temp_dir))
-        keys = [f"keep/f{i}.bin" for i in range(6000)]
-        keys += [f"drop/f{i}.bin" for i in range(6000)]
+        # Just over CHECK_RULES_BATCH, so more than one batch runs without
+        # making the test pay for tens of thousands of paths.
+        per_side = 3000
+        keys = [f"keep/f{i}.bin" for i in range(per_side)]
+        keys += [f"drop/f{i}.bin" for i in range(per_side)]
         selected = profile.select(keys)
 
-        self.assertEqual(len(selected), 6000)
+        self.assertEqual(len(selected), per_side)
         self.assertTrue(all(k.startswith("keep/") for k in selected))
 
 
@@ -202,7 +205,7 @@ class TestSyncRespectsSparseProfile(SparseRepoTestCase):
 
         self.assertTrue(Path("drop/out.bin").exists())
         self.assertEqual(Path("drop/out.bin").read_text(), "unsaved local work")
-        self.assertIn("local modifications", result.output)
+        self.assertIn("not in S3", result.output)
 
     def test_sync_no_prune_keeps_out_of_profile_files(self):
         self._track_both_dirs()


### PR DESCRIPTION
## Summary

Formal verification of the three properties asked for — that s3lfs tracks data correctly, doesn't leak it, and doesn't clobber or alias it — plus the fixes the models exposed, the remaining audit findings, and the project hygiene needed to cut a release.

## The models

Two new TLA+ specs cover the layer the existing ones didn't: the one that decides which bytes on disk get replaced or deleted.

**`specs/S3lfsWorkingCopy.tla`** — models `track`, `remove`, commit, branch switch, `sync` (download and prune) and `cleanup`, against a user who edits tracked files without uploading them:

| Invariant | Meaning |
|---|---|
| `NoDataLoss` | No automatic operation destroys content that exists only on disk |
| `NoDanglingReference` | Every manifest entry has an object behind it, so a checkout cannot 404 |
| `NoCollateralDeletion` | Distinct paths never share a storage key, so untracking one never destroys another's bytes |

**`specs/S3lfsOwnership.tla`** — models git/s3lfs ownership: `NoDualOwnership` (never versioned by both at once) and `NoOrphanedFile` (nothing on disk is hidden from git while absent from the manifest).

**Both directions are checked.** Each property is paired with a config that disables the design decision it rests on, and CI asserts those *still fail*:

```
S3lfsWorkingCopy_Fixed             (expect: holds)                      ok
S3lfsWorkingCopy_Large             (expect: holds)                      ok
S3lfsOwnership_PerFile             (expect: holds)                      ok
S3lfsWorkingCopy_NoGuard           (expect: NoDataLoss fails)           ok
S3lfsWorkingCopy_ContentAddressed  (expect: NoCollateralDeletion fails) ok
S3lfsOwnership_Directory           (expect: NoOrphanedFile fails)       ok
```

A property that holds no matter what the code does proves nothing, so the negative controls are the point. `specs/check.sh` runs all six; a new CI job runs it on every PR.

## The model changed the code

Checking the first version produced this counterexample:

```
track p2  →  commit  →  remove p2  →  cleanup  →  sync
```

`remove` drops the manifest entry, `cleanup` collects the now-unreferenced object, and `sync` then prunes the local file because it *still matches the recorded hash* — deleting the last copy. The guard I shipped in #108 asked the wrong question. It now asks the one the model requires: **only take bytes off disk when those bytes can be fetched back from S3**. That trace is pinned as `TestSyncNeverRemovesUnrecoverableContent`.

## Honest scope

This is model checking, not a proof about the Python. The models are hand-written abstractions over small bounded domains (a few paths, a few content values), so they establish that the design is sound and that specific defects are excluded — not that the code is bug-free. The practical value is the counterexample above, which no amount of testing had surfaced.

## Also included

**Audit fixes:** `install` no longer crashes in a linked worktree (`.git` is a file there); `sync` on a pre-s3lfs branch reports instead of erroring; the merge driver keeps null-valued keys, detects `.gitignore` by content when git omits `%P`, and no longer claims git "falls back" when it doesn't; unparseable manifests explain themselves and name conflict markers; NUL-delimited git I/O is handled as bytes; S3 listings paginate; `pre-commit` stages `.gitignore` and fails loudly if staging fails.

**Hygiene:** `s3lfs --version` (which `action.yml` had been calling all along); `endpoint_url` and `workers` in `.s3lfsconfig` — previously dropped silently, so a MinIO/R2 team's committed config sent every request to AWS; CI matrix across Python 3.9–3.13 plus macOS; `CONTRIBUTING.md` and `SECURITY.md`; removed the stale "cleanup is experimental and untested" warning (it has the most verification in the project); spec references now cite functions instead of drifted line numbers. Version bumped to 0.3.0.

**A defect in one of my own fixes:** the paginated listing looped on `IsTruncated` truthiness, which spins forever against any client whose fields are all truthy — it hung the test suite for several runs. It now continues only on a genuine continuation token, with a regression test.

## Testing

845 passed, 3 skipped in 2:57; black/isort/flake8/mypy clean; all six model checks agree with expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)