### PR TITLE
Shard the manifest, propagate deletions, and verify every model in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `s3lfs shard` splits the manifest into one file per top-level directory under `.s3lfs_manifest/`, leaving the root manifest holding configuration only. A flat manifest is parsed in full by every command and rewritten in full by every `track`, which also lands a fresh copy of the whole thing in git history each time; sharding confines a change under `data/` to `data`'s shard. `--undo` merges it back. The merge driver covers shards and the pre-commit hook stages them.
+- `s3lfs track` now records the hashes it computed into the hash cache, so the next modified-file scan is a cache hit rather than a re-read.
+- `specs/check.sh` now covers **every** model in `specs/`, not just the two newest: chunked upload, garbage collection, manifest locking, namespace exclusion, working-copy safety and ownership. For each protocol it names the configuration matching the shipped design and asserts it holds, and asserts that the configurations modelling known defects still fail on their stated invariant. Which configuration is "current" now lives in the script, so a stale label fails the build instead of misleading a reader.
+
+### Changed
+- Deleting a tracked file now removes its manifest entry on the next `track --modified`, so the deletion reaches collaborators instead of their sync re-downloading the file forever. A file that was never downloaded here is left alone -- the hash cache distinguishes "this working copy had it" from "never materialized", so a fresh clone cannot wipe the manifest. `--no-prune-deleted` opts out.
+- The `post-rewrite` hook takes its baseline from the first rewritten commit on stdin instead of `ORIG_HEAD`, which any reset, checkout or merge during an interactive rebase silently rewrites -- and a wrong baseline leaves files stale with no warning.
+- `verify --base` now unions the manifests of every commit in the range, not just the endpoints. Content introduced by an intermediate commit and superseded before the tip is still needed by anyone who checks that commit out.
+- The pre-commit and pre-push hooks warn when the repository uses s3lfs but `s3lfs` is not on `PATH` -- common when git is driven from an IDE. They previously did nothing at all, silently.
+
+### Fixed
+- `specs/README.md` described the chunked-upload defect as present in current code. It was fixed some releases ago; the code implements the verified `CommitAfter` design, and `check.sh` now enforces that.
+- `specs/check.sh` gives each model check its own TLC metadata directory. TLC names it from the wall clock to the second, so back-to-back runs of one module collided and the second died before checking anything -- which looked exactly like a property having changed. Failures now also print TLC's output, so "did not run" is distinguishable from "no longer holds".
+
 ## [0.3.0] - 2026-08-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -205,6 +205,19 @@ s3lfs sync --from HEAD~1
 - `--force`: Overwrite and delete locally modified files instead of keeping them
 - `--verbose`, `--no-sign-request`, `--endpoint-url`, `--workers`: As in other commands
 
+### Shard the Manifest
+```sh
+s3lfs shard
+s3lfs shard --undo
+```
+**Description**: Splits the manifest into one file per top-level directory under `.s3lfs_manifest/`, leaving `.s3_manifest.yaml` holding configuration only. Every command parses the manifest in full and every `track` rewrites it in full, which also lands a fresh copy of the whole thing in git history each time. Sharding means a change under `data/` rewrites only `data`'s shard.
+
+Commit the shards -- they *are* the manifest. `s3lfs install` registers the merge driver for them, and the pre-commit hook stages them alongside the root file.
+
+**Options**:
+- `--undo`: Merge the shards back into a single manifest file
+- `--force`: Skip the confirmation prompt
+
 ### Show Sparse Profile
 ```sh
 s3lfs sparse

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -10,7 +10,7 @@ import yaml
 
 from s3lfs import metrics
 from s3lfs.config import load_config
-from s3lfs.core import S3LFS, yaml_dump, yaml_load
+from s3lfs.core import MANIFEST_SHARD_DIR, S3LFS, yaml_dump, yaml_load
 from s3lfs.path_resolver import PathResolver
 from s3lfs.sparse import SparseProfile
 from s3lfs.utils import find_git_root
@@ -179,6 +179,11 @@ def init(bucket, prefix, no_sign_request, use_acceleration, endpoint_url):
     "--modified", is_flag=True, help="Track only modified files from manifest"
 )
 @click.option(
+    "--prune-deleted/--no-prune-deleted",
+    default=True,
+    help="Drop manifest entries for tracked files deleted from this working copy",
+)
+@click.option(
     "--metrics",
     "enable_metrics_flag",
     is_flag=True,
@@ -197,6 +202,7 @@ def track(
     endpoint_url,
     verbose,
     modified,
+    prune_deleted,
     enable_metrics_flag,
     workers,
 ):
@@ -225,7 +231,9 @@ def track(
 
     if modified:
         # Track only modified files using cached version for better performance
-        s3lfs.track_modified_files_cached(silence=not verbose)
+        s3lfs.track_modified_files_cached(
+            silence=not verbose, prune_deleted=prune_deleted
+        )
     elif manifest_key:
         # FILESYSTEM GLOB: Find files on disk and upload them
         # The manifest_key is converted to a filesystem path, then glob is applied
@@ -839,6 +847,59 @@ def cleanup(force, no_sign_request, use_acceleration, endpoint_url, workers):
     versioner.cleanup_s3(force=force)
 
 
+@cli.command()
+@click.option("--force", is_flag=True, help="Skip confirmation")
+@click.option(
+    "--undo", is_flag=True, help="Merge shards back into a single manifest file"
+)
+def shard(force, undo):
+    """Split the manifest into per-directory files, or merge it back.
+
+    One flat manifest is parsed in full by every command and rewritten in
+    full by every `track`, which also puts a fresh copy of the whole thing
+    into git history each time. Sharding by top-level directory means a
+    change under `data/` rewrites only `data`'s shard.
+
+    Commit the result: the shards are the manifest.
+    """
+    git_root, manifest_path, path_resolver = _setup_s3lfs_command()
+    s3lfs = _make_s3lfs(git_root, manifest_path)
+
+    if undo:
+        if not s3lfs.is_sharded:
+            click.echo("This manifest is not sharded; nothing to do.")
+            return
+        files = dict(s3lfs.manifest.get("files", {}))
+        shard_dir = s3lfs.shard_dir
+        s3lfs.manifest.pop("manifest_format", None)
+        s3lfs.manifest["files"] = files
+        s3lfs.save_manifest()
+        for path in sorted(shard_dir.glob("*.yaml")):
+            path.unlink()
+        shard_dir.rmdir() if not any(shard_dir.iterdir()) else None
+        click.echo(f"Merged {len(files)} entr(y/ies) back into {manifest_path.name}")
+        return
+
+    if s3lfs.is_sharded:
+        click.echo("This manifest is already sharded.")
+        return
+
+    files = dict(s3lfs.manifest.get("files", {}))
+    shards = sorted({s3lfs.shard_for(key) for key in files})
+    click.echo(
+        f"{len(files)} entr(y/ies) will move into {len(shards)} shard(s) under "
+        f"{manifest_path.parent.name}/{s3lfs.shard_dir.name}/"
+    )
+    if not force and not click.confirm("Proceed?"):
+        click.echo("Cancelled.")
+        return
+
+    s3lfs.manifest["manifest_format"] = "sharded"
+    s3lfs.save_manifest()
+    click.echo(f"Sharded into {len(shards)} file(s). Commit them along with")
+    click.echo(f"{manifest_path.name}, which now holds configuration only.")
+
+
 @click.command()
 @click.option("--force", is_flag=True, help="Skip confirmation and migrate immediately")
 def migrate(force):
@@ -1374,6 +1435,10 @@ def _protect_tracked_path(git_root, s3lfs, manifest_key):
         more = f" and {len(added) - 3} more" if len(added) > 3 else ""
         click.echo(f"Added {shown}{more} to .gitignore (s3lfs block)")
 
+    # The hashes were just computed from these files; keeping them makes
+    # the next scan cheap and lets a later deletion be recognised as one.
+    s3lfs.record_hashes(matched)
+
     removed = _deindex_tracked_files(git_root, matched.keys())
     if removed:
         click.echo(
@@ -1385,6 +1450,23 @@ def _protect_tracked_path(git_root, s3lfs, manifest_key):
         if len(removed) > 10:
             click.echo(f"  ... and {len(removed) - 10} more")
         click.echo("Commit to finalize their removal from git.")
+
+
+def _commits_between(git_root, base, revision):
+    """Commits reachable from *revision* but not *base*, oldest first.
+
+    Empty when either revision is unavailable locally, which is the normal
+    case for a first push to a new remote.
+    """
+    result = subprocess.run(
+        ["git", "rev-list", "--reverse", f"{base}..{revision}"],
+        capture_output=True,
+        text=True,
+        cwd=str(git_root),
+    )
+    if result.returncode != 0:
+        return []
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
 
 
 def _manifest_document_at_revision(git_root, revision):
@@ -1469,10 +1551,22 @@ _POST_REWRITE_BODY = """\
 #
 # `git pull --rebase` fires neither post-merge nor a branch post-checkout,
 # so without this hook the most common pull configuration leaves tracked
-# files stale. Amends ($1 = amend) rarely touch the manifest and leave
-# ORIG_HEAD stale, so they are skipped.
+# files stale. Amends ($1 = amend) rarely touch the manifest, so they are
+# skipped.
+#
+# git feeds "<old-sha> <new-sha>" per rewritten commit on stdin. The first
+# old-sha is a commit that existed before the rewrite, which makes a sound
+# baseline. ORIG_HEAD would be simpler but is rewritten by any reset,
+# checkout or merge the user runs while resolving an interactive rebase,
+# and a wrong baseline makes changed entries look unchanged -- leaving
+# files stale with no warning.
 if [ "$1" = "rebase" ] && command -v s3lfs >/dev/null 2>&1; then
-    if ! s3lfs sync --from ORIG_HEAD 2>&1; then
+    base=""
+    while read -r old new; do
+        [ -n "$base" ] || base="$old"
+    done
+    [ -n "$base" ] || base=ORIG_HEAD
+    if ! s3lfs sync --from "$base" 2>&1; then
         echo "s3lfs: ERROR: post-rewrite sync failed" >&2
         echo "s3lfs: large files may be missing or stale; run 's3lfs checkout --all'" >&2
     fi
@@ -1492,6 +1586,13 @@ if command -v s3lfs >/dev/null 2>&1; then
         echo "s3lfs: commit anyway with --no-verify if you are sure" >&2
         exit 1
     fi
+elif [ -f .s3_manifest.yaml ] || [ -f .s3_manifest.json ]; then
+    # This repository uses s3lfs but the command is not on PATH -- common
+    # when git is driven from an IDE or GUI that does not see a virtualenv.
+    # Staying silent here means the commit records stale hashes and nobody
+    # finds out until a collaborator's checkout 404s.
+    echo "s3lfs: WARNING: this repository uses s3lfs but 's3lfs' is not on PATH" >&2
+    echo "s3lfs: modified large files were NOT uploaded for this commit" >&2
 fi"""
 
 _PRE_PUSH_BODY = """\
@@ -1517,6 +1618,9 @@ if command -v s3lfs >/dev/null 2>&1; then
             exit 1
         fi
     done
+elif [ -f .s3_manifest.yaml ] || [ -f .s3_manifest.json ]; then
+    echo "s3lfs: WARNING: this repository uses s3lfs but 's3lfs' is not on PATH" >&2
+    echo "s3lfs: this push was NOT verified against S3" >&2
 fi"""
 
 HOOK_SCRIPTS = {
@@ -1842,7 +1946,10 @@ MERGE_DRIVER_COMMAND = "s3lfs merge-driver %O %A %B %P"
 MANIFEST_NAMES = (".s3_manifest.yaml", ".s3_manifest.json")
 # Both files are rewritten by every `s3lfs track`, so both conflict when
 # two branches track different files.
-MERGE_DRIVER_PATHS = MANIFEST_NAMES + (".gitignore",)
+MERGE_DRIVER_PATHS = MANIFEST_NAMES + (
+    ".gitignore",
+    f"{MANIFEST_SHARD_DIR}/*.yaml",
+)
 
 
 _ABSENT = object()
@@ -2066,6 +2173,33 @@ def merge_driver(base, ours, theirs, target):
         )
         raise SystemExit(1)
 
+    # A manifest shard is a flat map of entries with no wrapper, so the
+    # whole document is what needs merging. Detect it by path, falling back
+    # to shape when git does not pass one.
+    is_shard = (
+        MANIFEST_SHARD_DIR in Path(target).parts
+        if target
+        else not any("files" in d for d in (base_data, our_data, their_data))
+    )
+    if is_shard:
+        merged_shard, conflicts = _merge_maps(base_data, our_data, their_data)
+        with open(ours, "w") as f:
+            yaml_dump(merged_shard, f, default_flow_style=False, sort_keys=True)
+        if conflicts:
+            click.echo(
+                "s3lfs: manifest conflict -- both sides changed these entries:",
+                err=True,
+            )
+            for key in conflicts:
+                click.echo(f"  {key}", err=True)
+            click.echo(
+                "s3lfs: our version was kept for each; edit the shard and "
+                "'git add' it to resolve.",
+                err=True,
+            )
+            raise SystemExit(1)
+        return
+
     files, file_conflicts = _merge_maps(
         base_data.get("files") or {},
         our_data.get("files") or {},
@@ -2218,7 +2352,21 @@ def verify(revision, base, no_sign_request, use_acceleration, endpoint_url, work
 
     if base:
         base_files = _manifest_files_at_revision(git_root, base) or {}
-        files = {k: h for k, h in files.items() if base_files.get(k) != h}
+        pairs = set(files.items())
+
+        if revision:
+            # Union every manifest in base..revision, not just the tip's.
+            # Content introduced by an intermediate commit and superseded
+            # before the tip is still reachable -- anyone who checks out
+            # that commit needs it -- so checking only the endpoints would
+            # call the push safe when it is not. A path can legitimately
+            # appear with several hashes across the range; each one is a
+            # separate object that has to exist.
+            for sha in _commits_between(git_root, base, revision):
+                pairs |= set((_manifest_files_at_revision(git_root, sha) or {}).items())
+
+        pairs = {(k, h) for k, h in pairs if base_files.get(k) != h}
+        files = sorted(pairs)
 
     if not files:
         click.echo("No manifest entries to verify.")
@@ -2298,6 +2446,10 @@ def pre_commit(no_sign_request, use_acceleration, endpoint_url):
     to_stage = [manifest_path.name]
     if (git_root / ".gitignore").exists():
         to_stage.append(".gitignore")
+    # A sharded manifest lives in these files; staging only the root would
+    # commit configuration without the entries it describes.
+    if (git_root / MANIFEST_SHARD_DIR).is_dir():
+        to_stage.append(MANIFEST_SHARD_DIR)
 
     result = subprocess.run(
         ["git", "add", "--", *to_stage],

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -47,6 +47,11 @@ DEFAULT_THREAD_POOL_SIZE = 8  # Fallback when os.cpu_count() is unavailable
 DEFAULT_MULTIPART_THRESHOLD = 5 * 1024 * 1024 * 1024  # 5 GB
 DEFAULT_MAX_CONCURRENCY = 15  # Balanced for bandwidth-limited downloads
 
+# Sharded manifests keep entries in per-directory files under this directory,
+# beside the root manifest.
+MANIFEST_SHARD_DIR = ".s3lfs_manifest"
+MANIFEST_ROOT_SHARD = "_root"
+
 try:
     # The libyaml-backed loader parses and emits roughly an order of
     # magnitude faster than the pure-Python one. Every command reads the
@@ -277,6 +282,8 @@ class S3LFS:
         self._cache_mtime: Optional[float] = None
         self._cache_dirty = False
         self.hash_cache: dict = {}
+        self.manifest: dict = {"files": {}}
+        self._loaded_shards: dict = {}
         self.load_manifest()
         self.load_cache()
 
@@ -540,11 +547,16 @@ class S3LFS:
                 return None
             return item
 
-        if not files:
+        # Accepts a mapping or an iterable of (manifest_key, hash) pairs.
+        # A verification over a range of commits needs the latter: the same
+        # path can carry different content at different commits, and each
+        # one is a separate object that has to exist.
+        items = list(files.items()) if hasattr(files, "items") else list(files)
+        if not items:
             return []
 
         with ThreadPoolExecutor(max_workers=self.workers) as pool:
-            results = list(pool.map(check, files.items()))
+            results = list(pool.map(check, items))
         return [item for item in results if item is not None]
 
     def _get_s3_client(self):
@@ -652,8 +664,91 @@ class S3LFS:
         else:
             print(".gitignore already contains S3LFS cache exclusions")
 
+    @property
+    def shard_dir(self):
+        """Directory holding manifest shards, when the manifest is sharded."""
+        return self.manifest_file.parent / MANIFEST_SHARD_DIR
+
+    @staticmethod
+    def shard_for(manifest_key):
+        """Which shard a manifest key belongs to.
+
+        The first path component, so a change under one top-level directory
+        rewrites one small file instead of the whole manifest. That matters
+        twice over: every command parses what it loads, and every rewrite
+        becomes a new blob in git history.
+        """
+        head, sep, _ = manifest_key.partition("/")
+        return head if sep and head else MANIFEST_ROOT_SHARD
+
+    def _shard_path(self, shard):
+        # Shard names come from path components, so they can contain
+        # anything a directory name can. Percent-encode everything outside
+        # a conservative set rather than trusting them as filenames.
+        safe = "".join(
+            ch if ch.isalnum() or ch in "-_." else f"%{ord(ch):02x}" for ch in shard
+        )
+        return self.shard_dir / f"{safe}.yaml"
+
+    def _load_shards(self):
+        """Merge every shard into one files mapping."""
+        files: dict = {}
+        if not self.shard_dir.is_dir():
+            return files
+        for path in sorted(self.shard_dir.glob("*.yaml")):
+            try:
+                with open(path, "r") as f:
+                    data = yaml_load(f) or {}
+            except yaml.YAMLError as e:
+                hint = ""
+                if "<<<<<<<" in path.read_text(errors="replace"):
+                    hint = (
+                        " It contains merge conflict markers -- resolve the "
+                        "conflict, or run 's3lfs install' to register the "
+                        "merge driver that prevents it."
+                    )
+                raise RuntimeError(f"Cannot read manifest shard {path}: {e}.{hint}")
+            if isinstance(data, dict):
+                files.update(data)
+        return files
+
+    def _save_shards(self):
+        """Write only the shards whose contents actually changed."""
+        grouped: dict = {}
+        for key, file_hash in self.manifest.get("files", {}).items():
+            grouped.setdefault(self.shard_for(key), {})[key] = file_hash
+
+        self.shard_dir.mkdir(parents=True, exist_ok=True)
+        for shard, entries in grouped.items():
+            if self._loaded_shards.get(shard) == entries:
+                continue
+            self._write_atomic(self._shard_path(shard), entries)
+
+        # A shard that lost its last entry is removed, so an empty file does
+        # not linger in the tree forever.
+        for shard in set(self._loaded_shards) - set(grouped):
+            self._shard_path(shard).unlink(missing_ok=True)
+
+        self._loaded_shards = {s: dict(e) for s, e in grouped.items()}
+
+    def _write_atomic(self, path, data):
+        temp_file = path.with_name(f"{path.name}.{uuid4().hex}.tmp")
+        try:
+            with open(temp_file, "w") as f:
+                yaml_dump(data, f, default_flow_style=False, sort_keys=True)
+            temp_file.replace(path)
+        except Exception as e:
+            print(f"Failed to write {path}: {e}")
+            if temp_file.exists():
+                temp_file.unlink()
+
+    @property
+    def is_sharded(self):
+        return self.manifest.get("manifest_format") == "sharded"
+
     def load_manifest(self):
         """Load the local manifest (YAML or JSON format)."""
+        self._loaded_shards = {}
         if self.manifest_file.exists():
             try:
                 with open(self.manifest_file, "r") as f:
@@ -682,11 +777,25 @@ class S3LFS:
                     "it may have been overwritten."
                 )
             self.manifest.setdefault("files", {})
+            if self.is_sharded:
+                # The root file carries configuration only; entries live in
+                # per-directory shards beside it.
+                self.manifest["files"] = self._load_shards()
+                for key, file_hash in self.manifest["files"].items():
+                    self._loaded_shards.setdefault(self.shard_for(key), {})[
+                        key
+                    ] = file_hash
         else:
             self.manifest = {"files": {}}  # Use file paths as keys
 
     def save_manifest(self):
         """Save the manifest back to disk atomically (YAML or JSON format)."""
+        if self.is_sharded:
+            self._save_shards()
+            root = {k: v for k, v in self.manifest.items() if k != "files"}
+            self._write_atomic(self.manifest_file, root)
+            return
+
         # Unique temp name. A shared one lets two writers interleave into the
         # same file before either renames: the rename is atomic, the content
         # is not.
@@ -1160,7 +1269,41 @@ class S3LFS:
 
         return hashes
 
-    def track_modified_files_cached(self, silence=True, keys=None):
+    def record_hashes(self, entries):
+        """Record known hashes for files currently on disk.
+
+        Called after an upload, where the hash was just computed from the
+        bytes on disk. Two reasons to keep it: the next modified-file scan
+        gets a cache hit instead of re-reading the file, and the cache
+        becomes a reliable record of what this working copy has actually
+        held -- which is how a file the user deleted is told apart from one
+        that was never downloaded here.
+        """
+        updates = {}
+        for manifest_key, file_hash in entries.items():
+            filesystem_path = self.path_resolver.to_filesystem_path(manifest_key)
+            try:
+                stat = filesystem_path.stat()
+            except OSError:
+                continue
+            updates[str(Path(manifest_key).as_posix())] = {
+                "hash": file_hash,
+                "metadata": {
+                    "size": stat.st_size,
+                    "mtime": stat.st_mtime,
+                    "inode": getattr(stat, "st_ino", None),
+                },
+                "timestamp": time.time(),
+            }
+        if not updates:
+            return
+        with self._lock_context():
+            self.load_cache()
+            self.hash_cache.update(updates)
+            self._cache_dirty = True
+            self.save_cache()
+
+    def track_modified_files_cached(self, silence=True, keys=None, prune_deleted=True):
         """
         Check manifest for outdated hashes using cached hashing and upload
         changed files in parallel.
@@ -1173,8 +1316,13 @@ class S3LFS:
             of the whole manifest. A sparse working copy passes its
             profile here so the per-commit cost tracks the slice it has
             on disk rather than the size of the repository.
+        :param prune_deleted: drop manifest entries for files this working
+            copy had and the user deleted. Without it a deletion never
+            reaches collaborators: their next sync downloads the file again,
+            and keeps doing so forever.
         """
         files_to_upload = []
+        deleted = []
         cache_hits = 0
         cache_misses = 0
 
@@ -1208,7 +1356,18 @@ class S3LFS:
                     filesystem_path = self.path_resolver.to_filesystem_path(file_path)
 
                     if not filesystem_path.exists():
-                        print(f"Warning: File {file_path} is missing. Skipping.")
+                        # Absent for one of two very different reasons. If
+                        # this working copy has hashed the file before, it
+                        # was here and the user deleted it -- a real change
+                        # that should reach collaborators. If it has never
+                        # been hashed here, it was simply never downloaded
+                        # (a fresh clone, or outside a sparse profile), and
+                        # untracking it would delete other people's data.
+                        cache_key = str(fp.as_posix())
+                        if cache_key in self.hash_cache:
+                            deleted.append(file_path)
+                        else:
+                            print(f"Warning: File {file_path} is missing. Skipping.")
                         pbar.update(1)
                         continue
 
@@ -1261,6 +1420,25 @@ class S3LFS:
         if not silence:
             print(
                 f"Hash cache performance: " f"{cache_hits} hits, {cache_misses} misses"
+            )
+
+        if deleted and prune_deleted:
+            with self._lock_context():
+                self.load_manifest()
+                for file_path in deleted:
+                    self.manifest["files"].pop(file_path, None)
+                self.save_manifest()
+            noun = "entry" if len(deleted) == 1 else "entries"
+            print(f"Removed {len(deleted)} manifest {noun} for deleted file(s):")
+            for file_path in sorted(deleted)[:10]:
+                print(f"  {file_path}")
+            if len(deleted) > 10:
+                print(f"  ... and {len(deleted) - 10} more")
+            print("The objects stay in S3 so earlier commits still check out.")
+        elif deleted:
+            print(
+                f"{len(deleted)} tracked file(s) were deleted here but left "
+                "in the manifest."
             )
 
         # Upload files in parallel if needed
@@ -2483,6 +2661,10 @@ class S3LFS:
         if ".git" in parts:
             return True
         if ".s3lfs_temp" in parts or self.temp_dir.name in parts:
+            return True
+        # Manifest shards are the manifest. Tracking them would upload the
+        # index of what is tracked into the store it indexes.
+        if MANIFEST_SHARD_DIR in parts:
             return True
         if resolved.name in {self.manifest_file.name, self.cache_file.name}:
             return True

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,6 +1,18 @@
 # TLA+ specifications
 
-Formal models of s3lfs's concurrency-sensitive protocols, checked with TLC.
+Formal models of s3lfs's concurrency-sensitive protocols and of the operations
+that can lose data, checked with TLC.
+
+`specs/check.sh` runs every configuration whose expected outcome is known and
+fails if any disagrees. CI runs it on every pull request. It checks both
+directions: configurations modelling the shipped design must hold, and
+configurations modelling a defect the code no longer has must still violate
+their invariant -- otherwise the corresponding property is vacuous and proves
+nothing about the code.
+
+Which configuration corresponds to the shipped design is recorded in
+`check.sh`, not only in prose here, so a stale label fails the build rather
+than misleading a reader.
 
 References below name functions rather than line numbers, which go stale as
 the code moves.
@@ -97,7 +109,7 @@ a file the manifest claims is tracked.
 Three configurations, selected by the `REVALIDATE` and `INFLIGHT` constants:
 
 ```sh
-java -jar tla2tools.jar -config S3lfsGC.cfg         S3lfsGC.tla  # current code
+java -jar tla2tools.jar -config S3lfsGC.cfg         S3lfsGC.tla  # original defect
 java -jar tla2tools.jar -config S3lfsGCFixed.cfg    S3lfsGC.tla  # revalidate under lock
 java -jar tla2tools.jar -config S3lfsGCInflight.cfg S3lfsGC.tla  # in-flight registry
 ```
@@ -215,7 +227,13 @@ Models `S3LFS.parallel_upload_chunked` followed by the checkout that
 reassembles the file (`S3LFS._discover_chunks_for_file`,
 `S3LFS._finalize_file`).
 
-Three defects interact:
+**The code now implements `CommitAfter`.** `parallel_upload_chunked` records a
+manifest entry only once every chunk of that file has landed, and prints a
+warning naming any file whose chunks did not all upload. `specs/check.sh`
+asserts `CommitAfter` holds and that `Baseline` still violates
+`NoSilentCorruption`, so a regression toward the original behaviour fails CI.
+
+The three defects the `Baseline` configuration models, kept for the record:
 
 1. The manifest entry is recorded at *prep* time, in `_prepare_file_for_upload`,
    before any chunk is PUT.
@@ -237,7 +255,7 @@ done
 
 | Config | `NoSilentCorruption` | `ManifestImpliesChunks` |
 | --- | --- | --- |
-| `Baseline` (current code) | Violated | Violated |
+| `Baseline` (the original defect, since fixed) | Violated | Violated |
 | `StoreCount` | No error | Violated |
 | `VerifyHash` | No error | Violated |
 | `CommitAfter` | No error | **No error** |

--- a/specs/check.sh
+++ b/specs/check.sh
@@ -1,10 +1,16 @@
 #!/bin/sh
-# Run the TLA+ models whose expected outcome is known, and fail if any of
+# Run every TLA+ model whose expected outcome is known, and fail if any of
 # them disagrees.
 #
-# Both outcomes matter. A model that should hold must hold; a model of a
-# known defect must still violate its invariant, otherwise the property is
-# vacuous and proves nothing about the code.
+# Both outcomes matter. A configuration modelling the shipped design must
+# hold. A configuration modelling a defect the code does not have must
+# still violate its invariant -- otherwise the property is vacuous and
+# proves nothing about the code.
+#
+# The "holds" list is the load-bearing part: it names, for each protocol,
+# the configuration that corresponds to what the code actually does. If a
+# change regresses the code back toward a modelled defect, the matching
+# entry here starts failing.
 #
 # Usage: specs/check.sh   (downloads tla2tools.jar if absent)
 
@@ -18,44 +24,105 @@ if [ ! -f tla2tools.jar ]; then
         https://github.com/tlaplus/tlaplus/releases/latest/download/tla2tools.jar
 fi
 
+module_for() {
+    case "$1" in
+        S3lfsGC|S3lfsGCFixed|S3lfsGCInflight) echo S3lfsGC ;;
+        *) echo "$1" | sed 's/_.*//' ;;
+    esac
+}
+
 run() {
+    # Each run gets its own metadir. TLC names it from the wall clock to the
+    # second by default, so back-to-back runs of the same module collide and
+    # the second one dies before it checks anything -- which looks exactly
+    # like the property having changed.
+    meta="${TMPDIR:-/tmp}/tlc-meta-$1"
+    rm -rf "$meta"
     java -XX:+UseParallelGC -cp tla2tools.jar tlc2.TLC \
-        -config "$2.cfg" -workers auto "$1.tla" 2>&1
+        -metadir "$meta" -config "$1.cfg" -workers auto \
+        "$(module_for "$1").tla" > "${TMPDIR:-/tmp}/tlc_$1.out" 2>&1 || true
+    rm -rf "$meta"
+    cat "${TMPDIR:-/tmp}/tlc_$1.out"
+}
+
+# A model check can also fail to run at all -- out of memory, a parse error,
+# a missing config. That is a different problem from a property changing,
+# and saying so saves the reader from chasing the wrong one.
+explain() {
+    echo "   TLC output (last lines):"
+    tail -5 "${TMPDIR:-/tmp}/tlc_$1.out" | sed "s/^/   | /"
 }
 
 failures=0
 
-# Configurations that must pass: module, config
-for pair in \
-    "S3lfsWorkingCopy S3lfsWorkingCopy_Fixed" \
-    "S3lfsWorkingCopy S3lfsWorkingCopy_Large" \
-    "S3lfsOwnership   S3lfsOwnership_PerFile"
+# Configurations modelling the shipped design: these must hold.
+#
+#   S3lfsChunks_CommitAfter        a manifest entry is written only once every
+#                                  chunk has landed (parallel_upload_chunked)
+#   S3lfsGCInflight                uploads in flight are registered so a
+#                                  concurrent sweep cannot collect them
+#   S3lfsCombined_Fixed            the two above interacting
+#   S3lfsManifest_Reload_Lock      the manifest is re-read under the lock
+#                                  before every read-modify-write
+#   S3lfsNamespace_*_trackS        s3lfs's own metadata is excluded from the
+#                                  tree it enumerates (_is_internal_path)
+#   S3lfsWorkingCopy_Fixed         sync only removes bytes it can fetch back
+#   S3lfsOwnership_PerFile         .gitignore covers exactly what is tracked
+for cfg in \
+    S3lfsChunks_CommitAfter \
+    S3lfsChunks_CommitAndVerify \
+    S3lfsChunks_CommitAndVerifyLarge \
+    S3lfsGCInflight \
+    S3lfsCombined_Fixed \
+    S3lfsCombined_FixedLarge \
+    S3lfsManifest_Reload_Lock \
+    S3lfsManifest_Reload_Lock_Large \
+    S3lfsNamespace_manifest_root_trackS \
+    S3lfsNamespace_manifest_temp_trackS \
+    S3lfsWorkingCopy_Fixed \
+    S3lfsWorkingCopy_Large \
+    S3lfsOwnership_PerFile
 do
-    # shellcheck disable=SC2086
-    set -- $pair
-    printf '%-34s ' "$2 (expect: holds)"
-    if run "$1" "$2" | grep -q "No error has been found"; then
+    printf '%-38s ' "$cfg (holds)"
+    if run "$cfg" | grep -q "No error has been found"; then
         echo "ok"
     else
-        echo "FAILED -- an invariant that should hold does not"
+        echo "FAILED -- an invariant the shipped design relies on does not hold"
+        explain "$cfg"
         failures=$((failures + 1))
     fi
 done
 
-# Configurations modelling a known defect: module, config, invariant
-for triple in \
-    "S3lfsWorkingCopy S3lfsWorkingCopy_NoGuard          NoDataLoss" \
-    "S3lfsWorkingCopy S3lfsWorkingCopy_ContentAddressed NoCollateralDeletion" \
-    "S3lfsOwnership   S3lfsOwnership_Directory          NoOrphanedFile"
+# Configurations modelling a defect: these must still fail, on the stated
+# invariant. If one starts passing, the model has stopped discriminating
+# and the matching "holds" entry no longer proves anything.
+for pair in \
+    "S3lfsChunks_Baseline                NoSilentCorruption" \
+    "S3lfsGC                             NoDanglingReference" \
+    "S3lfsGCFixed                        NoDanglingReference" \
+    "S3lfsCombined_Broken                NoLostUpdate" \
+    "S3lfsCombined_ReloadOnly            NoDanglingReference" \
+    "S3lfsCombined_RevalOnly             NoDanglingReference" \
+    "S3lfsManifest_NoReload_Lock         NoLostUpdate" \
+    "S3lfsManifest_NoReload_NoLock       NoLostUpdate" \
+    "S3lfsManifest_Reload_NoLock         NoLostUpdate" \
+    "S3lfsNamespace_cwd_temp_trackR      NoInternalFileTracked" \
+    "S3lfsNamespace_cwd_temp_trackS      NoInternalFileTracked" \
+    "S3lfsNamespace_manifest_root_trackR NoInternalFileTracked" \
+    "S3lfsNamespace_manifest_temp_trackR NoInternalFileTracked" \
+    "S3lfsWorkingCopy_NoGuard            NoDataLoss" \
+    "S3lfsWorkingCopy_ContentAddressed   NoCollateralDeletion" \
+    "S3lfsOwnership_Directory            NoOrphanedFile"
 do
     # shellcheck disable=SC2086
-    set -- $triple
-    printf '%-34s ' "$2 (expect: $3 fails)"
-    if run "$1" "$2" | grep -q "Error: Invariant $3 is violated"; then
+    set -- $pair
+    printf '%-38s ' "$1 ($2 fails)"
+    if run "$1" | grep -q "Error: Invariant $2 is violated"; then
         echo "ok"
     else
-        echo "FAILED -- the modelled defect no longer violates $3, so the"
-        echo "   property is vacuous and proves nothing about the code"
+        echo "FAILED -- the modelled defect no longer violates $2, so the"
+        echo "   corresponding property is vacuous and proves nothing"
+        explain "$1"
         failures=$((failures + 1))
     fi
 done

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -1140,3 +1140,129 @@ class TestSyncNeverRemovesUnrecoverableContent(GitRepoTestCase):
 
         self.assertEqual(result.exit_code, 0, msg=result.output)
         self.assertFalse(Path("data/a.bin").exists())
+
+
+class TestDeletionsPropagate(GitRepoTestCase):
+    """A tracked file the user deletes must stop being tracked.
+
+    Otherwise the deletion never reaches collaborators: their next sync
+    downloads the file again, and keeps doing so forever.
+    """
+
+    def test_deleting_a_tracked_file_untracks_it(self):
+        self._write("data/a.bin", "a")
+        self._write("data/b.bin", "b")
+        self.runner.invoke(cli, ["track", "data"])
+        self._commit_all("track both")
+
+        Path("data/a.bin").unlink()
+        result = self.runner.invoke(cli, ["track", "--modified"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        files = yaml.safe_load(Path(".s3_manifest.yaml").read_text())["files"]
+        self.assertNotIn("data/a.bin", files)
+        self.assertIn("data/b.bin", files)
+        self.assertIn("data/a.bin", result.output)
+
+    def test_never_downloaded_files_are_not_untracked(self):
+        """The dangerous case: a fresh clone has every tracked file absent.
+
+        Untracking on absence alone would wipe the manifest and delete
+        everyone else's data. Only files this working copy has actually
+        hashed count as deleted.
+        """
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+
+        # Simulate a clone: file absent, and no local hash cache
+        Path("data/a.bin").unlink()
+        for cache in Path(".").glob(".s3_manifest_cache.*"):
+            cache.unlink()
+
+        result = self.runner.invoke(cli, ["track", "--modified"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        files = yaml.safe_load(Path(".s3_manifest.yaml").read_text())["files"]
+        self.assertIn("data/a.bin", files)
+
+    def test_no_prune_deleted_keeps_the_entry(self):
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+
+        Path("data/a.bin").unlink()
+        result = self.runner.invoke(cli, ["track", "--modified", "--no-prune-deleted"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        files = yaml.safe_load(Path(".s3_manifest.yaml").read_text())["files"]
+        self.assertIn("data/a.bin", files)
+
+
+class TestShardedManifest(GitRepoTestCase):
+    """One flat manifest is parsed and rewritten in full by every command,
+    and lands a fresh copy in git history on every track."""
+
+    def _shard_files(self):
+        return sorted(p.name for p in Path(".s3lfs_manifest").glob("*.yaml"))
+
+    def test_shard_splits_by_top_level_directory(self):
+        self._write("data/a.bin", "a")
+        self._write("models/b.bin", "b")
+        self._write("root.bin", "c")
+        self.runner.invoke(cli, ["track", "data"])
+        self.runner.invoke(cli, ["track", "models"])
+        self.runner.invoke(cli, ["track", "root.bin"])
+
+        result = self.runner.invoke(cli, ["shard", "--force"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        self.assertEqual(
+            self._shard_files(), ["_root.yaml", "data.yaml", "models.yaml"]
+        )
+        root = yaml.safe_load(Path(".s3_manifest.yaml").read_text())
+        self.assertEqual(root.get("manifest_format"), "sharded")
+        self.assertNotIn("files", root)
+
+    def test_entries_survive_the_round_trip(self):
+        self._write("data/a.bin", "a")
+        self._write("models/b.bin", "b")
+        self.runner.invoke(cli, ["track", "data"])
+        self.runner.invoke(cli, ["track", "models"])
+        before = self.runner.invoke(cli, ["ls"]).output
+
+        self.runner.invoke(cli, ["shard", "--force"])
+        self.assertEqual(self.runner.invoke(cli, ["ls"]).output, before)
+
+        self.runner.invoke(cli, ["shard", "--undo", "--force"])
+        self.assertEqual(self.runner.invoke(cli, ["ls"]).output, before)
+        self.assertFalse(Path(".s3lfs_manifest").exists())
+
+    def test_tracking_rewrites_only_the_affected_shard(self):
+        """The point of sharding: a change under one directory does not
+        produce a new copy of the whole manifest in git history."""
+        self._write("data/a.bin", "a")
+        self._write("models/b.bin", "b")
+        self.runner.invoke(cli, ["track", "data"])
+        self.runner.invoke(cli, ["track", "models"])
+        self.runner.invoke(cli, ["shard", "--force"])
+
+        untouched = Path(".s3lfs_manifest/models.yaml")
+        before = untouched.read_bytes()
+        stamp = untouched.stat().st_mtime_ns
+
+        self._write("data/c.bin", "c")
+        self.runner.invoke(cli, ["track", "data/c.bin"])
+
+        self.assertIn("data/c.bin", Path(".s3lfs_manifest/data.yaml").read_text())
+        self.assertEqual(untouched.read_bytes(), before)
+        self.assertEqual(untouched.stat().st_mtime_ns, stamp)
+
+    def test_shards_are_not_themselves_tracked(self):
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self.runner.invoke(cli, ["shard", "--force"])
+
+        self.runner.invoke(cli, ["track", "."])
+        listed = self.runner.invoke(cli, ["ls"]).output
+        self.assertNotIn(".s3lfs_manifest", listed)


### PR DESCRIPTION
## Summary

All four items from the "what next" list.

### 1. CI now checks every model, not just the newest two

`specs/check.sh` covered only `S3lfsWorkingCopy` and `S3lfsOwnership`. The strongest properties in the project — no silent truncation on partial chunk upload, no lost manifest updates, GC not deleting live objects — were proven on paper and **unguarded**. It now covers all seven models, 29 configurations:

- For each protocol it names the configuration matching the shipped design and asserts it **holds**.
- It asserts the configurations modelling known defects still **fail on their stated invariant** — otherwise the matching property is vacuous.

Which configuration is "current" lives in the script rather than in prose, so a stale label fails the build.

**That paid off immediately.** `specs/README.md` described the chunked-upload defect as present in current code. It isn't: `parallel_upload_chunked` implements the verified `CommitAfter` design, recording a manifest entry only once every chunk has landed, with a warning naming incomplete files. The doc was two fixes out of date and would have sent a reader hunting a data-corruption bug that doesn't exist. Corrected, and now enforced.

Two infrastructure fixes fell out: each check gets its own TLC metadata directory (TLC names it from the wall clock *to the second*, so back-to-back runs of one module collided and the second died before checking anything — indistinguishable from a property changing), and failures print TLC's output so "didn't run" is distinguishable from "no longer holds".

### 2. Manifest sharding

`s3lfs shard` splits the manifest into one file per top-level directory under `.s3lfs_manifest/`. Measured on a 20,000-entry manifest:

| | before | after |
|---|---|---|
| manifest file | 1.84 MB | 72 bytes (config only) |
| largest unit rewritten by `track` | 1.84 MB | 0.09 MB |
| files | 1 | 20 shards |

A `track` under `data/` rewrites only `data`'s shard — verified by asserting the untouched shard's bytes *and* mtime are unchanged. Shards are covered by the merge driver, staged by the pre-commit hook, and excluded from what `track` enumerates. `--undo` merges back.

This is the storage half; the in-memory API is unchanged, so reads still load everything. Lazy per-shard loading for sparse checkouts is the natural follow-up.

### 3. Deletions propagate

Deleting a tracked file now removes its manifest entry, instead of collaborators re-downloading it forever.

The dangerous case is a fresh clone, where **every** tracked file is absent — untracking on absence alone would wipe the manifest and delete everyone's data. The hash cache distinguishes "this working copy had it" from "never materialized here". For that to be reliable, `track` now records the hashes it already computed (which also makes the next scan a cache hit). `--no-prune-deleted` opts out. Both branches are tested, including the fresh-clone case.

### 4. Hook gaps

- `post-rewrite` takes its baseline from the first rewritten commit on stdin rather than `ORIG_HEAD`, which any reset/checkout/merge during an interactive rebase silently rewrites — and a wrong baseline leaves files stale with no warning.
- `verify --base` unions every manifest in the range, not just the endpoints: content introduced by an intermediate commit and superseded before the tip is still needed by anyone checking that commit out.
- pre-commit and pre-push now warn when the repo uses s3lfs but `s3lfs` isn't on `PATH` (common when git runs from an IDE). They previously did nothing, silently.

## Testing

852 passed, 3 skipped; black/isort/flake8/mypy clean; all 29 model checks agree with expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)