### PR TITLE
Make the model checks deterministic across machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The pre-commit and pre-push hooks warn when the repository uses s3lfs but `s3lfs` is not on `PATH` -- common when git is driven from an IDE. They previously did nothing at all, silently.
 
 ### Fixed
+- `specs/check.sh` runs the configurations that expect a violation with a single TLC worker, and accepts any of the invariants a multi-defect configuration legitimately breaks. TLC stops at the first violation it finds, so with several workers the invariant reported depends on which state a machine reaches first -- the check passed locally and failed in CI on a different core count.
 - `specs/README.md` described the chunked-upload defect as present in current code. It was fixed some releases ago; the code implements the verified `CommitAfter` design, and `check.sh` now enforces that.
 - `specs/check.sh` gives each model check its own TLC metadata directory. TLC names it from the wall clock to the second, so back-to-back runs of one module collided and the second died before checking anything -- which looked exactly like a property having changed. Failures now also print TLC's output, so "did not run" is distinguishable from "no longer holds".
 

--- a/specs/check.sh
+++ b/specs/check.sh
@@ -36,10 +36,16 @@ run() {
     # second by default, so back-to-back runs of the same module collide and
     # the second one dies before it checks anything -- which looks exactly
     # like the property having changed.
+    #
+    # $2 is the worker count. Exhaustive runs can use every core: the verdict
+    # does not depend on exploration order. Runs that expect a violation use
+    # one worker, because TLC stops at the first one it finds and a
+    # configuration modelling several defects would otherwise report
+    # whichever invariant a given machine happened to reach first.
     meta="${TMPDIR:-/tmp}/tlc-meta-$1"
     rm -rf "$meta"
     java -XX:+UseParallelGC -cp tla2tools.jar tlc2.TLC \
-        -metadir "$meta" -config "$1.cfg" -workers auto \
+        -metadir "$meta" -config "$1.cfg" -workers "$2" \
         "$(module_for "$1").tla" > "${TMPDIR:-/tmp}/tlc_$1.out" 2>&1 || true
     rm -rf "$meta"
     cat "${TMPDIR:-/tmp}/tlc_$1.out"
@@ -84,7 +90,7 @@ for cfg in \
     S3lfsOwnership_PerFile
 do
     printf '%-38s ' "$cfg (holds)"
-    if run "$cfg" | grep -q "No error has been found"; then
+    if run "$cfg" auto | grep -q "No error has been found"; then
         echo "ok"
     else
         echo "FAILED -- an invariant the shipped design relies on does not hold"
@@ -100,7 +106,7 @@ for pair in \
     "S3lfsChunks_Baseline                NoSilentCorruption" \
     "S3lfsGC                             NoDanglingReference" \
     "S3lfsGCFixed                        NoDanglingReference" \
-    "S3lfsCombined_Broken                NoLostUpdate" \
+    "S3lfsCombined_Broken                NoLostUpdate|NoDanglingReference" \
     "S3lfsCombined_ReloadOnly            NoDanglingReference" \
     "S3lfsCombined_RevalOnly             NoDanglingReference" \
     "S3lfsManifest_NoReload_Lock         NoLostUpdate" \
@@ -117,7 +123,7 @@ do
     # shellcheck disable=SC2086
     set -- $pair
     printf '%-38s ' "$1 ($2 fails)"
-    if run "$1" | grep -q "Error: Invariant $2 is violated"; then
+    if run "$1" 1 | grep -qE "Error: Invariant ($2) is violated"; then
         echo "ok"
     else
         echo "FAILED -- the modelled defect no longer violates $2, so the"


### PR DESCRIPTION
## Summary

The **Model checking (TLA+)** job passed locally and failed on CI after #111.

TLC stops at the first invariant violation it finds. `S3lfsCombined_Broken` models two defects at once and lists several invariants, so which one is reported depends on the order workers explore states in — my 8-core machine reported `NoLostUpdate`, the CI runner reported a different one, and the check demanded an exact match.

Configurations that expect a violation now run with a single worker, and the expected invariant may be an alternation where a configuration legitimately breaks more than one. Exhaustive runs keep using every core, since their verdict doesn't depend on exploration order.

This is the check being wrong, not the models: the property still holds and the defect still fails.

## Testing

`./specs/check.sh`: all 29 configurations agree with expectations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)