### PR TITLE
Release 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] - 2026-08-08
 
 ### Added
 - `s3lfs shard` splits the manifest into one file per top-level directory under `.s3lfs_manifest/`, leaving the root manifest holding configuration only. A flat manifest is parsed in full by every command and rewritten in full by every `track`, which also lands a fresh copy of the whole thing in git history each time; sharding confines a change under `data/` to `data`'s shard. `--undo` merges it back. The merge driver covers shards and the pre-commit hook stages them.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3lfs"
-version = "0.3.0"
+version = "0.4.0"
 description = "A Python-based version control system for large assets using Amazon S3."
 authors = [{name = "Kevin Blackburn-Matzen", email = "kmatzen@gmail.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump and changelog date for 0.4.0. Contents are PRs #111, #112 and #113, already merged and verified on `main`.

**Headline changes**

- `s3lfs shard` — manifest split by top-level directory, so `track` rewrites one small file instead of putting a fresh copy of the whole manifest into git history each time. Opt-in and reversible.
- Deleting a tracked file now untracks it, so deletions reach collaborators — with three guards against the ways that could misfire (fresh clone, sparse prune, wiped working copy).
- `specs/check.sh` now covers every model in `specs/`, in both directions, and runs on every PR.

**Known caveats, stated in the release notes**

- Sharding is a new on-disk format that has not been exercised on a real repository yet.
- The bulk-deletion guard is a threshold heuristic, not a proven invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)