### PR TITLE
Explain why a commit of only tracked files looks empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- `git commit -a` with only s3lfs-tracked files changed aborted with git's "nothing to commit, working tree clean", which is misleading: the pre-commit hook had already uploaded the content and updated the manifest, and running the same command again committed it. `git commit -a` prepares its commit from a temporary index before hooks run, so it decides there is nothing to commit without seeing the manifest change. The hook now says so. Commits that also touch git-tracked files were never affected -- the manifest update lands in those normally.
+
 ## [0.4.0] - 2026-08-08
 
 ### Added

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -2477,6 +2477,40 @@ def pre_commit(no_sign_request, use_acceleration, endpoint_url):
         click.echo(result.stderr.strip())
         raise SystemExit(1)
 
+    _warn_if_commit_will_look_empty(git_root, to_stage)
+
+
+def _warn_if_commit_will_look_empty(git_root, staged_paths):
+    """Explain git's "nothing to commit" when only tracked files changed.
+
+    `git commit -a` builds the commit from a temporary index prepared
+    before hooks run, so it decides whether there is anything to commit
+    without seeing the manifest this hook just updated. When the only
+    edits are to s3lfs-tracked files -- which are gitignored, so git sees
+    nothing else -- git aborts with "nothing to commit, working tree
+    clean". That is misleading: the content is uploaded and the manifest
+    has changed, and running the same command again commits it.
+    """
+    index_file = os.environ.get("GIT_INDEX_FILE")
+    if not index_file or Path(index_file).name == "index":
+        return  # the ordinary index; staging from here lands normally
+
+    changed = subprocess.run(
+        ["git", "diff", "--quiet", "HEAD", "--", *staged_paths],
+        cwd=str(git_root),
+    )
+    if changed.returncode == 0:
+        return  # manifest unchanged, so nothing to explain
+
+    click.echo(
+        "s3lfs: the manifest changed, but this commit was prepared before "
+        "that happened."
+    )
+    click.echo(
+        "s3lfs: if git says 'nothing to commit', run the same command again "
+        "-- the upload is done and the manifest is ready to commit."
+    )
+
 
 cli.add_command(init)
 cli.add_command(track)

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -1326,3 +1326,48 @@ class TestBulkDeletionGuard(GitRepoTestCase):
         files = yaml.safe_load(Path(".s3_manifest.yaml").read_text())["files"]
         self.assertNotIn("data/f0.bin", files)
         self.assertEqual(len(files), 7)
+
+
+class TestCommitDashAMessage(GitRepoTestCase):
+    """`git commit -a` prepares its commit before hooks run, so when the
+    only edits are to tracked (gitignored) files git decides there is
+    nothing to commit without seeing the manifest the hook just updated.
+    The bare "nothing to commit, working tree clean" is misleading."""
+
+    def test_explains_why_the_commit_looks_empty(self):
+        self._write("data/a.bin", "v1")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+
+        self._write("data/a.bin", "v2")
+        result = self.runner.invoke(
+            cli, ["pre-commit"], env={"GIT_INDEX_FILE": ".git/index.lock"}
+        )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("run the same command again", result.output)
+
+    def test_silent_for_an_ordinary_commit(self):
+        self._write("data/a.bin", "v1")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+
+        self._write("data/a.bin", "v2")
+        result = self.runner.invoke(
+            cli, ["pre-commit"], env={"GIT_INDEX_FILE": ".git/index"}
+        )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertNotIn("run the same command again", result.output)
+
+    def test_silent_when_the_manifest_did_not_change(self):
+        self._write("data/a.bin", "v1")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+
+        result = self.runner.invoke(
+            cli, ["pre-commit"], env={"GIT_INDEX_FILE": ".git/index.lock"}
+        )
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertNotIn("run the same command again", result.output)


### PR DESCRIPTION
## Summary

Found by exercising sharding on a **real repository** — a clone of `pallets/click` (165 files, real history), 87 real files tracked, a real S3 server over HTTP, driven by the **released 0.4.0 from PyPI** rather than in-process mocks.

Sharding itself worked: the manifest went from 8,243 bytes to 109, split into `docs.yaml` (3.5 KB) and `tests.yaml` (4.4 KB); `s3lfs ls` still saw all 87 files; `s3lfs verify` confirmed all 87 present in S3; and git stored the shards as ordinary small files. Fidelity was exact — git had 41 files under `docs/`, s3lfs tracked 41.

But the workflow test surfaced this:

```
$ git commit -am "Edit only a tracked asset"
nothing to commit, working tree clean          # exit 1
$ git commit -am "Edit only a tracked asset"   # identical command
[main ddeda19] Edit only a tracked asset       # works
```

## Cause

`git commit -a` builds its commit from a temporary index prepared **before** hooks run — `GIT_INDEX_FILE` points at `.git/index.lock`, confirmed by probing it. So git decides whether there is anything to commit without seeing what the pre-commit hook staged. Since tracked files are gitignored, an asset-only edit looks to git like no change at all.

Meanwhile the hook *had* done its work: content uploaded to S3, manifest shard updated. The message "working tree clean" was simply false — the shard was modified.

This is the tool's most common workflow, since editing assets is the point of it.

## Scope — what is *not* affected

I checked the worse possibility: a mixed commit touching both a source file and an asset. That works correctly — the commit included the updated manifest with the new hash (`2 files changed`), so no commit has ever carried stale hashes through this path. No data loss, no silent staleness; a confusing message on the first of two attempts.

## Fix

The hook now detects that git is using a temporary index *and* that the manifest actually changed, and explains what happened instead of leaving git's misleading message as the only output. Verified on the real repository.

## Testing

Three unit tests (explains under a temp index; silent for an ordinary commit; silent when the manifest didn't change), plus the real-repository run above. 860 passed, 3 skipped; black/isort/flake8/mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)