### PR TITLE
Release 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.1] - 2026-08-08
 
 ### Fixed
 - `git commit -a` with only s3lfs-tracked files changed aborted with git's "nothing to commit, working tree clean", which is misleading: the pre-commit hook had already uploaded the content and updated the manifest, and running the same command again committed it. `git commit -a` prepares its commit from a temporary index before hooks run, so it decides there is nothing to commit without seeing the manifest change. The hook now says so. Commits that also touch git-tracked files were never affected -- the manifest update lands in those normally.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3lfs"
-version = "0.4.0"
+version = "0.4.1"
 description = "A Python-based version control system for large assets using Amazon S3."
 authors = [{name = "Kevin Blackburn-Matzen", email = "kmatzen@gmail.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump and changelog date for 0.4.1. Contents are PR #115, already merged and verified on `main`.

Fixes the misleading `nothing to commit, working tree clean` when the only edits are to s3lfs-tracked files — found by exercising 0.4.0 on a real repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)