### PR TITLE
Release 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.0] - 2026-08-09
 
 ### Changed
 - A sharded manifest is now read one shard at a time. Constructing `S3LFS` parses no shards at all; looking up or writing a path parses that path's shard only; iterating still parses everything, because that is what the caller asked for. On a 200,000-entry manifest across 100 shards (18.4 MB): construction went from parsing all of it to 0 shards, a single lookup reads 1 shard in 10 ms, and a three-shard slice costs 24 ms against 861 ms for the whole manifest.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3lfs"
-version = "0.4.1"
+version = "0.5.0"
 description = "A Python-based version control system for large assets using Amazon S3."
 authors = [{name = "Kevin Blackburn-Matzen", email = "kmatzen@gmail.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump and changelog date for 0.5.0. Contents are PR #117, already merged and verified on `main`.

- Sharded manifests are read one shard at a time; a sparse working copy never opens the shards its profile cannot reach (`s3lfs status` 6.8s → 0.32s on a 200,000-entry manifest).
- Fixes a blocking bug for anyone already using sharding: enabling a git sparse checkout removed the whole manifest from the working copy, and s3lfs reported that nothing was tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)