### PR TITLE
Annotate the benchmark script for mypy

### DIFF
--- a/benchmarks/manifest_scaling.py
+++ b/benchmarks/manifest_scaling.py
@@ -30,8 +30,8 @@ def timed(fn):
 def build(root, entries, shards, sharded):
     """Write a manifest of *entries* keys spread over *shards* directories."""
     per = entries // shards
-    files = {}
-    grouped = {}
+    files: dict = {}
+    grouped: dict = {}
     for s in range(shards):
         name = f"dir{s:03d}"
         group = {
@@ -43,7 +43,7 @@ def build(root, entries, shards, sharded):
         grouped[name] = group
         files.update(group)
 
-    config = {"bucket_name": "b", "repo_prefix": "p"}
+    config: dict = {"bucket_name": "b", "repo_prefix": "p"}
     if sharded:
         config["manifest_format"] = "sharded"
         shard_dir = root / ".s3lfs_manifest"


### PR DESCRIPTION
CI's mypy checks every file. My local `pre-commit run --all-files` did not check this one: pre-commit only looks at files git knows about, and the benchmark script was still untracked when I ran it. Staging first would have caught it.

Three dict annotations; no behavior change. Verified with the file staged this time, and by running the script at another size.

🤖 Generated with [Claude Code](https://claude.com/claude-code)