### PR TITLE
Stop making git status quadratic in tracked files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - README gained a Performance section with measured numbers for manifest size, sharding and sparse reads, replacing a single inline claim.
 
+### Fixed
+- **`s3lfs track <dir>` made `git status` quadratic.** Since 0.3.0 it wrote one `.gitignore` entry per tracked file, and git matches every candidate path against every pattern with no pruning: at 100,000 tracked files `git status` took **69.6 seconds**, against 17 ms for a single directory pattern. A directory now becomes one `/dir/` pattern again -- 37 ms at the same scale.
+- The precision that bought is recovered without the cost: `s3lfs status` and the pre-commit hook now report files under a tracked directory that s3lfs is not tracking, which would otherwise be invisible to git *and* absent from the manifest. On every commit the scan is bounded by directory mtime -- adding a file updates its directory -- so it costs ~70 ms over 100,000 files instead of ~1 s for a full walk.
+
 ## [0.5.0] - 2026-08-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -79,7 +79,9 @@ s3lfs track --modified                   # Track only changed files
 
 **Git protection**: Tracking a path also adds it to a marked block in `.gitignore` (so `git add .` won't commit the large files to git) and, if any of the files were already committed to git, removes them from the git index (`git rm --cached`; the files stay on disk). `s3lfs remove` removes the corresponding `.gitignore` entries again.
 
-A literal path or directory becomes one `.gitignore` entry per tracked file, not a blanket `/dir/` pattern -- so a source file added under a tracked directory later stays visible to git rather than being silently ignored by one tool and untracked by the other. A glob spec (`"*.mp4"`) is used as-is, since it is already precise.
+A directory becomes a single `/dir/` pattern, a file becomes one entry, and a glob (`"*.mp4"`) is used as-is. One entry per tracked file would be more precise, but git matches every candidate path against every pattern with no pruning, so the cost is quadratic -- at 100,000 tracked files a per-file block took `git status` from 17ms to 70s.
+
+The precision that buys is recovered elsewhere: because a directory pattern also hides anything put there later, `s3lfs status` and the pre-commit hook report files under a tracked directory that s3lfs is *not* tracking. Such a file would otherwise be invisible to git and absent from the manifest -- present on one machine and gone on the next clone. The check on every commit is bounded by directory mtime, so it costs ~70ms over 100,000 files rather than a full walk.
 
 ### Checkout Files
 ```sh

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -861,6 +861,21 @@ def status(path, show_all, porcelain, no_sign_request, use_acceleration, endpoin
         for key in up_to_date:
             click.echo(f"  {display(key)}")
 
+    hidden = _hidden_untracked_files(
+        git_root, s3lfs, set(expected) | set(outside_profile)
+    )
+    if hidden:
+        click.echo()
+        click.echo(
+            f"Hidden from git but not tracked by s3lfs ({len(hidden)}) -- these "
+            "exist only here:"
+        )
+        for key in hidden[:20]:
+            click.echo(f"  {display(key)}")
+        if len(hidden) > 20:
+            click.echo(f"  ... and {len(hidden) - 20} more")
+        click.echo("Track them with 's3lfs track <path>', or ignore them yourself.")
+
 
 @click.command()
 @click.argument("path", required=True)
@@ -1455,22 +1470,84 @@ def _has_glob(spec):
     return any(ch in spec for ch in "*?[")
 
 
-def _gitignore_entries_for(spec, matched_keys):
-    """Root-anchored .gitignore patterns covering what a spec actually tracked.
+def _gitignore_entries_for(git_root, spec, matched_keys):
+    """Root-anchored .gitignore patterns covering what a spec tracked.
 
     A glob spec is used verbatim: it is already precise, and gitignore
     gives an unanchored '*' the same single-level meaning glob.glob does.
+    A directory becomes one directory pattern, and a single file one entry.
 
-    Anything else expands to one entry per tracked file rather than a
-    directory pattern. `/data/` would ignore everything under data/ for
-    all time, so a source file added there later is invisible to git
-    (ignored) *and* to s3lfs (not in the manifest) -- it exists only on
-    one machine. Listing the tracked files ignores exactly what s3lfs
-    stores and nothing else.
+    One entry per tracked file would be more precise, but git matches every
+    candidate path against every pattern with no pruning, so the cost is
+    quadratic: at 100,000 tracked files a per-file block took `git status`
+    from 17ms to 70s. What precision bought -- noticing a file added under
+    a tracked directory that s3lfs is not tracking -- is recovered by
+    `_hidden_untracked_files`, which looks at the directory itself.
     """
+    key = spec.rstrip("/")
+    literal = git_root / key
+    # Decide the same way path resolution does: an existing path is taken
+    # literally even when it contains glob characters, so `runs[2024]/a.bin`
+    # must be escaped rather than left to read as a character class.
+    if literal.is_dir():
+        return [f"/{_escape_gitignore(key)}/"]
+    if literal.is_file():
+        return [f"/{_escape_gitignore(key)}"]
     if _has_glob(spec):
         return [f"/{spec}"]
-    return [f"/{_escape_gitignore(key)}" for key in sorted(matched_keys)]
+    return [f"/{_escape_gitignore(key)}"]
+
+
+# Editor and OS droppings, skipped when reporting what is hidden under a
+# tracked directory. A directory pattern prunes the whole tree, so git
+# never evaluates the user's own rules for anything inside it and cannot
+# tell us whether they would have ignored these.
+def _hidden_untracked_files(git_root, s3lfs, tracked, limit=200, since=None):
+    """Files hidden by an s3lfs directory pattern that s3lfs is not tracking.
+
+    A directory pattern keeps `git add .` from swallowing large files, but
+    it also hides anything else put there later. Such a file would be
+    invisible to git and absent from the manifest -- present on one machine
+    and gone on the next clone -- so s3lfs reports it rather than letting
+    it disappear quietly.
+
+    :param since: only descend into directories modified after this time.
+        Adding a file updates its directory's mtime, so this checks the
+        directories rather than every file, which is what makes the scan
+        affordable on every commit. Pass None for an exhaustive scan.
+    """
+    _, entries, _ = _load_gitignore_block(git_root)
+    directories = [e.rstrip("/").lstrip("/") for e in entries if e.endswith("/")]
+    if not directories:
+        return []
+
+    skip_dirs = {".git", ".s3lfs_temp", MANIFEST_SHARD_DIR}
+    skip_names = {".DS_Store", "Thumbs.db"}
+    skip_suffixes = (".tmp", ".swp", ".swo", ".pyc", "~")
+
+    found = []
+    for directory in directories:
+        root = git_root / directory
+        if not root.is_dir():
+            continue
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in skip_dirs]
+            if since is not None:
+                try:
+                    if os.stat(dirpath).st_mtime <= since:
+                        continue
+                except OSError:
+                    continue
+            base = Path(dirpath)
+            for name in filenames:
+                if name in skip_names or name.endswith(skip_suffixes):
+                    continue
+                key = str((base / name).relative_to(git_root).as_posix())
+                if key not in tracked:
+                    found.append(key)
+                    if len(found) >= limit:
+                        return sorted(found)
+    return sorted(found)
 
 
 def _deindex_tracked_files(git_root, tracked_keys):
@@ -1536,7 +1613,7 @@ def _protect_tracked_path(git_root, s3lfs, manifest_key):
         return
 
     added = _add_gitignore_entries(
-        git_root, _gitignore_entries_for(manifest_key, matched.keys())
+        git_root, _gitignore_entries_for(git_root, manifest_key, matched.keys())
     )
     if added:
         shown = ", ".join(f"'{e}'" for e in added[:3])
@@ -2575,6 +2652,23 @@ def pre_commit(no_sign_request, use_acceleration, endpoint_url):
         raise SystemExit(1)
 
     _warn_if_commit_will_look_empty(git_root, to_stage)
+
+    try:
+        since = manifest_path.stat().st_mtime
+    except OSError:
+        since = None
+    hidden = _hidden_untracked_files(git_root, s3lfs, tracked, limit=20, since=since)
+    if hidden:
+        click.echo(
+            f"Warning: {len(hidden)} file(s) under a tracked directory are "
+            "hidden from git and not tracked by s3lfs, so they exist only on "
+            "this machine:"
+        )
+        for key in hidden[:5]:
+            click.echo(f"  {key}")
+        if len(hidden) > 5:
+            click.echo(f"  ... and {len(hidden) - 5} more")
+        click.echo("Track them with 's3lfs track <path>', or ignore them yourself.")
 
 
 def _warn_if_commit_will_look_empty(git_root, staged_paths):

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 
@@ -159,12 +160,12 @@ class TestTrackProtectsFromGit(GitRepoTestCase):
         check = self._git("check-ignore", "data/big.bin")
         self.assertEqual(check.returncode, 0, "tracked file is not gitignored")
 
-    def test_track_directory_ignores_each_tracked_file(self):
-        """A directory spec must not ignore the directory wholesale.
+    def test_track_directory_uses_one_directory_pattern(self):
+        """One pattern, not one per file.
 
-        `/data/` would hide any source file added there later from git,
-        while s3lfs would not be tracking it either -- the file would live
-        on one machine only.
+        git matches every candidate path against every pattern with no
+        pruning, so a per-file block is quadratic: at 100,000 tracked files
+        it took `git status` from 17ms to 70s.
         """
         self._write("data/a.bin", "a")
         self._write("data/sub/b.bin", "b")
@@ -172,16 +173,47 @@ class TestTrackProtectsFromGit(GitRepoTestCase):
         self.assertEqual(result.exit_code, 0, msg=result.output)
 
         _, entries, _ = _load_gitignore_block(Path(self.temp_dir))
-        self.assertEqual(entries, ["/data/a.bin", "/data/sub/b.bin"])
+        self.assertEqual(entries, ["/data/"])
         self.assertEqual(self._git("check-ignore", "data/sub/b.bin").returncode, 0)
 
-        # A file added under the tracked directory afterwards stays visible
+    def test_a_file_added_under_a_tracked_directory_is_reported(self):
+        """The directory pattern hides anything put there later, so s3lfs
+        reports what it is hiding but not tracking -- otherwise the file is
+        invisible to both systems and lost on the next clone."""
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data"])
+
         self._write("data/schema.json", "{}")
-        self.assertNotEqual(
+        self.assertEqual(
             self._git("check-ignore", "data/schema.json").returncode,
             0,
-            "a newly added source file was hidden from git",
+            "the directory pattern should hide it from git",
         )
+
+        result = self.runner.invoke(cli, ["status"])
+        self.assertIn("data/schema.json", result.output)
+        self.assertIn("exist only here", result.output)
+
+    def test_editor_droppings_are_not_reported(self):
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data"])
+        self._write("data/.DS_Store", "junk")
+        self._write("data/x.tmp", "junk")
+
+        result = self.runner.invoke(cli, ["status"])
+        self.assertNotIn(".DS_Store", result.output)
+        self.assertNotIn("x.tmp", result.output)
+
+    def test_pre_commit_warns_about_hidden_untracked_files(self):
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data"])
+        self._commit_all("track data")
+        self._write("data/schema.json", "{}")
+
+        result = self.runner.invoke(cli, ["pre-commit"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("data/schema.json", result.output)
+        self.assertIn("only on this machine", result.output)
 
     def test_track_glob_keeps_the_glob(self):
         """A glob is already precise, so it is used as-is."""
@@ -200,14 +232,14 @@ class TestTrackProtectsFromGit(GitRepoTestCase):
         matches nothing, so the file would stay visible to git and get
         committed -- the outcome the .gitignore block exists to prevent.
         """
-        self._write("data/runs[2024]/a.bin", "a")
-        result = self.runner.invoke(cli, ["track", "data"])
+        self._write("runs[2024]/a.bin", "a")
+        result = self.runner.invoke(cli, ["track", "runs[2024]/a.bin"])
         self.assertEqual(result.exit_code, 0, msg=result.output)
 
         _, entries, _ = _load_gitignore_block(Path(self.temp_dir))
-        self.assertEqual(entries, [r"/data/runs\[2024\]/a.bin"])
+        self.assertEqual(entries, [r"/runs\[2024\]/a.bin"])
         self.assertEqual(
-            self._git("check-ignore", "data/runs[2024]/a.bin").returncode,
+            self._git("check-ignore", "runs[2024]/a.bin").returncode,
             0,
             "tracked file under a bracketed directory is not ignored",
         )
@@ -1427,3 +1459,54 @@ class TestLazyShardLoading(GitRepoTestCase):
 
         self.assertIn("alpha/new.bin", Path(".s3lfs_manifest/alpha.yaml").read_text())
         self.assertEqual(untouched.stat().st_mtime_ns, stamp)
+
+
+class TestHiddenFileScanCost(GitRepoTestCase):
+    """The scan that replaces per-file .gitignore entries runs on every
+    commit, so it is bounded by directory mtime: adding a file updates its
+    directory, which is far cheaper to check than every file."""
+
+    def test_bounded_scan_skips_unchanged_directories(self):
+        self._write("data/a.bin", "a")
+        self._write("data/deep/b.bin", "b")
+        self.runner.invoke(cli, ["track", "data"])
+
+        from s3lfs.cli import _hidden_untracked_files
+        from s3lfs.core import S3LFS
+
+        s3lfs = S3LFS(
+            bucket_name=TEST_BUCKET,
+            manifest_file=".s3_manifest.yaml",
+            s3_factory=lambda no_sign: None,
+        )
+        tracked = set(s3lfs.manifest["files"])
+        root = Path(self.temp_dir)
+
+        # Nothing added since: a bounded scan finds nothing.
+        future = time.time() + 60
+        self.assertEqual(
+            _hidden_untracked_files(root, s3lfs, tracked, since=future), []
+        )
+
+        # A file added afterwards updates its directory's mtime.
+        self._write("data/deep/schema.json", "{}")
+        found = _hidden_untracked_files(root, s3lfs, tracked, since=0)
+        self.assertIn("data/deep/schema.json", found)
+
+    def test_unbounded_scan_finds_it_too(self):
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data"])
+        self._write("data/notes.md", "notes")
+
+        from s3lfs.cli import _hidden_untracked_files
+        from s3lfs.core import S3LFS
+
+        s3lfs = S3LFS(
+            bucket_name=TEST_BUCKET,
+            manifest_file=".s3_manifest.yaml",
+            s3_factory=lambda no_sign: None,
+        )
+        found = _hidden_untracked_files(
+            Path(self.temp_dir), s3lfs, set(s3lfs.manifest["files"])
+        )
+        self.assertEqual(found, ["data/notes.md"])


### PR DESCRIPTION
## Summary

Since 0.3.0, `s3lfs track <dir>` has written **one `.gitignore` entry per tracked file**. I made that change to fix a real bug — a source file added under a tracked directory was invisible to git *and* absent from the manifest, so it lived on one machine only — but I never measured what it cost.

git matches every candidate path against every pattern with no pruning, so it is quadratic:

| `.gitignore` entries | `git status` |
|---|---|
| 1,000 | 44 ms |
| 5,000 | 249 ms |
| 10,000 | 838 ms |
| 100,000 | **69,573 ms** |
| one `/dir/` pattern | **17 ms** |

Same repository, same files, same ignored outcome — the only variable is pattern count. Every `git status`, `git add` and `git commit` in a large repository was unusable, which undercut the manifest work: opening a 200,000-entry manifest is 20 ms while git itself was crippled by the ignore file sitting next to it.

**A directory is one `/dir/` pattern again — 37 ms at 100,000 tracked files, from 69.6 s.**

## Keeping the safety property

The precision is recovered by looking at the directory instead of enumerating it in `.gitignore`. `s3lfs status` and the pre-commit hook now report files under a tracked directory that s3lfs is *not* tracking:

```
Hidden from git but not tracked by s3lfs (1) -- these exist only here:
  data/schema.json
Track them with 's3lfs track <path>', or ignore them yourself.
```

Since that runs on every commit, the scan is **bounded by directory mtime** — adding a file updates its directory, which is far cheaper to check than every file:

| scan | 100,000 files |
|---|---|
| full walk (`s3lfs status`) | 1,050 ms |
| mtime-bounded (pre-commit) | **66 ms** |
| mtime-bounded, one file added | 74 ms (finds it) |

The first version of the scan took 4.4 s because it called `Path.resolve()` per file; removing that got the full walk to ~1 s, and the mtime bound handles the hook path.

## A limitation I'd rather state than hide

A directory pattern prunes the whole tree, so git never evaluates the user's own ignore rules for anything inside it and cannot tell us whether they would have ignored a given file. I verified this with `git check-ignore -v`: files under `/data/` report *our* pattern even when a later `*.tmp` rule would have matched. The report therefore skips a small fixed set of editor and OS droppings (`.DS_Store`, `*.tmp`, `*.swp`, `*.pyc`, `*~`, `Thumbs.db`) rather than consulting the user's rules. If that proves noisy in practice, a config key is the natural follow-up.

Also fixed in passing: the escaping rule now decides literal-vs-glob the way path resolution does — by whether the path exists — so `runs[2024]/a.bin` is escaped rather than left to read as a character class.

## Testing

Six new tests: one directory pattern per directory spec, the hidden-file report in `status` and in pre-commit, editor droppings skipped, and the mtime-bounded scan both skipping unchanged directories and finding a newly added file.

872 passed, 3 skipped; `pre-commit run --all-files` clean with everything staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)