### PR TITLE
Replace per-file .gitignore entries when re-tracking a directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`s3lfs track <dir>` made `git status` quadratic.** Since 0.3.0 it wrote one `.gitignore` entry per tracked file, and git matches every candidate path against every pattern with no pruning: at 100,000 tracked files `git status` took **69.6 seconds**, against 17 ms for a single directory pattern. A directory now becomes one `/dir/` pattern again -- 37 ms at the same scale.
+- Re-tracking a directory replaces the old per-file entries rather than adding the directory pattern alongside them. Without that, upgrading fixed nothing for the repositories that needed it most: the slow block stayed in place.
 - The precision that bought is recovered without the cost: `s3lfs status` and the pre-commit hook now report files under a tracked directory that s3lfs is not tracking, which would otherwise be invisible to git *and* absent from the manifest. On every commit the scan is bounded by directory mtime -- adding a file updates its directory -- so it costs ~70 ms over 100,000 files instead of ~1 s for a full walk.
 
 ## [0.5.0] - 2026-08-09

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -1598,6 +1598,38 @@ def _deindex_tracked_files(git_root, tracked_keys):
     return offenders
 
 
+def _apply_gitignore_entries(git_root, entries):
+    """Add these entries, dropping any a new directory entry makes redundant.
+
+    Versions 0.3.0-0.5.0 wrote one entry per tracked file. Adding the
+    directory pattern without removing those would leave the quadratic
+    block in place, so upgrading would fix nothing for the repositories
+    that need it most. Returns (added, removed).
+    """
+    before, existing, after = _load_gitignore_block(git_root)
+    directories = tuple(e for e in entries if e.endswith("/"))
+
+    kept, removed = [], []
+    for entry in existing:
+        if entry not in directories and entry.startswith(directories):
+            removed.append(entry)
+        else:
+            kept.append(entry)
+
+    added = [e for e in entries if e not in kept]
+    if not added and not removed:
+        return [], []
+    _save_marked_block(
+        git_root / ".gitignore",
+        S3LFS_GITIGNORE_START,
+        S3LFS_GITIGNORE_END,
+        before,
+        kept + added,
+        after,
+    )
+    return added, removed
+
+
 def _protect_tracked_path(git_root, s3lfs, manifest_key):
     """Keep a newly tracked path spec out of git: ignore it and de-index it."""
     s3lfs.load_manifest()
@@ -1612,9 +1644,15 @@ def _protect_tracked_path(git_root, s3lfs, manifest_key):
         )
         return
 
-    added = _add_gitignore_entries(
+    added, removed = _apply_gitignore_entries(
         git_root, _gitignore_entries_for(git_root, manifest_key, matched.keys())
     )
+    if removed:
+        click.echo(
+            f"Replaced {len(removed)} per-file .gitignore entr(y/ies) with a "
+            "directory pattern; git matches every path against every pattern, "
+            "so the per-file form made 'git status' quadratic."
+        )
     if added:
         shown = ", ".join(f"'{e}'" for e in added[:3])
         more = f" and {len(added) - 3} more" if len(added) > 3 else ""

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -1510,3 +1510,40 @@ class TestHiddenFileScanCost(GitRepoTestCase):
             Path(self.temp_dir), s3lfs, set(s3lfs.manifest["files"])
         )
         self.assertEqual(found, ["data/notes.md"])
+
+
+class TestGitignoreUpgrade(GitRepoTestCase):
+    """0.3.0-0.5.0 wrote one .gitignore entry per tracked file, which made
+    git status quadratic. Adding the directory pattern without removing
+    those would leave the slow block in place, so upgrading would fix
+    nothing for the repositories that need it most."""
+
+    def test_per_file_entries_are_replaced_by_the_directory(self):
+        for i in range(5):
+            self._write(f"data/f{i}.bin", str(i))
+        Path(".gitignore").write_text(
+            f"{S3LFS_GITIGNORE_START}\n"
+            + "".join(f"/data/f{i}.bin\n" for i in range(5))
+            + f"{S3LFS_GITIGNORE_END}\n"
+        )
+
+        result = self.runner.invoke(cli, ["track", "data"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+
+        _, entries, _ = _load_gitignore_block(Path(self.temp_dir))
+        self.assertEqual(entries, ["/data/"])
+        self.assertIn("Replaced 5", result.output)
+        self.assertEqual(self._git("check-ignore", "data/f0.bin").returncode, 0)
+
+    def test_unrelated_entries_are_left_alone(self):
+        self._write("data/a.bin", "a")
+        self._write("other/b.bin", "b")
+        Path(".gitignore").write_text(
+            f"{S3LFS_GITIGNORE_START}\n/other/b.bin\n{S3LFS_GITIGNORE_END}\n"
+        )
+
+        self.runner.invoke(cli, ["track", "data"])
+
+        _, entries, _ = _load_gitignore_block(Path(self.temp_dir))
+        self.assertIn("/other/b.bin", entries)
+        self.assertIn("/data/", entries)


### PR DESCRIPTION
## Summary

Follow-up to #121, found by testing the **upgrade** path rather than the fresh-install path.

#121 made `track <dir>` write a single directory pattern — but only for entries it was adding. An existing block written by 0.3.0–0.5.0 kept all its per-file lines and merely gained `/dir/` alongside them:

```
before: ['/data/f0.bin', '/data/f1.bin', '/data/f2.bin', '/data/f3.bin', '/data/f4.bin']
after:  ['/data/f0.bin', ..., '/data/f4.bin', '/data/']     ← still quadratic
```

So upgrading fixed nothing for exactly the repositories that need it: a 100,000-entry block stayed 100,000 entries long and `git status` stayed at ~70 s.

Now:

```
before: ['/data/f0.bin', '/data/f1.bin', '/data/f2.bin', '/data/f3.bin', '/data/f4.bin']
after:  ['/data/']
```

with `Replaced 5 per-file .gitignore entr(y/ies) with a directory pattern` explaining why. Entries outside that directory are untouched.

## Testing

Two tests: per-file entries under the tracked directory are replaced (and the files stay ignored), and unrelated entries survive. 874 passed, 3 skipped; `pre-commit run --all-files` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)