### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.1] - 2026-08-09
 
 ### Added
 - `benchmarks/manifest_scaling.py`, which generates a synthetic manifest of a given size and times the operations every command depends on. The README's performance figures come from it, so they can be re-derived rather than taken on faith.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3lfs"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Python-based version control system for large assets using Amazon S3."
 authors = [{name = "Kevin Blackburn-Matzen", email = "kmatzen@gmail.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump and changelog date for 0.5.1. Contents are PRs #119, #121 and #122, already merged and verified on `main`.

The headline is a performance regression fix: `s3lfs track <dir>` wrote one `.gitignore` entry per tracked file from 0.3.0 onward, which made `git status` quadratic — 69.6s at 100,000 tracked files, against 37ms now. #122 makes re-tracking replace an existing per-file block, so upgrading actually helps repositories that already have one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)