### PR TITLE
Keep the pre-commit hook quiet when it has nothing to say

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- The pre-commit hook is quiet when it has nothing to report. It printed a per-file progress bar and a running commentary on every commit -- noise the user could not turn off, which buried the messages that do matter. It still reports what it uploaded, files hidden under a tracked directory, and anything it blocks; `s3lfs track --modified --verbose` still shows progress.
+
 ## [0.5.1] - 2026-08-09
 
 ### Added

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -1495,12 +1495,19 @@ class S3LFS:
             )
             return
 
-        print(f"Checking {len(files_to_check)} tracked files for modifications...")
+        if not silence:
+            print(f"Checking {len(files_to_check)} tracked files for modifications...")
 
         cache_updates = {}
 
+        # Quiet when the caller asked for quiet. This runs from the
+        # pre-commit hook on every commit, where a progress bar for a scan
+        # that usually finds nothing is just noise across the terminal.
         with tqdm(
-            total=len(files_to_check), desc="Checking files", unit="file"
+            total=len(files_to_check),
+            desc="Checking files",
+            unit="file",
+            disable=silence,
         ) as pbar:
             for file_path in files_to_check:
                 try:
@@ -1622,7 +1629,7 @@ class S3LFS:
             # again here would write this process's older in-memory copy back
             # over anything another process committed in between.
             self.parallel_upload(files_to_upload, silence=silence)
-        else:
+        elif not silence:
             print("No modified files needing upload.")
 
     def _hash_file_mmap(self, file_path):

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -1547,3 +1547,39 @@ class TestGitignoreUpgrade(GitRepoTestCase):
         _, entries, _ = _load_gitignore_block(Path(self.temp_dir))
         self.assertIn("/other/b.bin", entries)
         self.assertIn("/data/", entries)
+
+
+class TestHookQuietness(GitRepoTestCase):
+    """The pre-commit hook runs on every commit. A progress bar and a
+    running commentary for a scan that usually finds nothing is noise the
+    user cannot turn off, and it buries the messages that do matter."""
+
+    def test_pre_commit_says_nothing_when_there_is_nothing_to_say(self):
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+
+        result = self.runner.invoke(cli, ["pre-commit"])
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertNotIn("Checking files", result.output)
+        self.assertNotIn("file/s", result.output)
+        self.assertNotIn("No modified files needing upload", result.output)
+
+    def test_it_still_reports_what_it_uploaded(self):
+        self._write("data/a.bin", "v1")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+        self._commit_all("track a")
+        self._write("data/a.bin", "v2")
+
+        result = self.runner.invoke(cli, ["pre-commit"])
+
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("data/a.bin", result.output)
+
+    def test_verbose_track_still_shows_progress(self):
+        self._write("data/a.bin", "a")
+        self.runner.invoke(cli, ["track", "data/a.bin"])
+
+        result = self.runner.invoke(cli, ["track", "--modified", "--verbose"])
+        self.assertIn("Checking", result.output)


### PR DESCRIPTION
## Summary

Found by exercising a real repository (a clone of `pallets/click`, 87 tracked files, released 0.5.1, real S3 over HTTP).

Every commit printed this:

```
Checking 87 tracked files for modifications...
Checking files:   0%|          | 0/87 [00:00<?, ?file/s]Checking files:   1%|  ...
   ... ~90 more progress frames ...
No modified files needing upload.
[main 467501b] an ordinary commit
```

A per-file progress bar and a running commentary, on every commit, for a scan that usually finds nothing. The user cannot turn it off, and it buries the messages that matter — I had to filter it out of my own terminal repeatedly while testing, which is what made me notice.

Now an ordinary commit prints nothing from s3lfs at all. What still gets through, verified on the same repository:

```
Uploaded 1 file(s) (1 chunks, 0.0 MB compressed).          ← an asset changed
  docs/newthing.json                                       ← hidden but untracked
Track them with 's3lfs track <path>', or ignore them yourself.
```

and `s3lfs track --modified --verbose` still shows progress.

## Testing

Three tests: silent when there's nothing to report, still reports uploads, and `--verbose` still shows progress. 877 passed, 3 skipped; `pre-commit run --all-files` clean with everything staged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)