### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.2] - 2026-08-09
 
 ### Changed
 - The pre-commit hook is quiet when it has nothing to report. It printed a per-file progress bar and a running commentary on every commit -- noise the user could not turn off, which buried the messages that do matter. It still reports what it uploaded, files hidden under a tracked directory, and anything it blocks; `s3lfs track --modified --verbose` still shows progress.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3lfs"
-version = "0.5.1"
+version = "0.5.2"
 description = "A Python-based version control system for large assets using Amazon S3."
 authors = [{name = "Kevin Blackburn-Matzen", email = "kmatzen@gmail.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump and changelog date for 0.5.2. Contents are PR #124, already merged and verified on `main`.

Quiets the pre-commit hook: it printed a per-file progress bar and a running commentary on every commit, which buried the messages that matter. Found by exercising 0.5.1 on a real repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)