### PR TITLE
Load boto3 lazily and request the CRT transfer client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `benchmarks/transfer_comparison.py`: measures s3lfs against a raw transfer tool (s5cmd) across cold/no-op/incremental upload and download, per scenario rather than as one misleading number.
 
 ### Changed
+- boto3 and package metadata are imported lazily, cutting CLI startup from ~200ms to ~135ms for anything that does not touch S3 -- `--help`, `--version`, and hooks with nothing to do. A test asserts importing the CLI does not pull in boto3, so the cost cannot creep back silently.
+- The S3 transfer configuration requests boto3's CRT client in "auto" mode. With `pip install s3lfs[crt]`, transfers to standard AWS S3 endpoints use AWS's C-based engine; everything else (MinIO, R2, older boto3) falls back to the classic client unchanged.
 - A missing stored object is now a loud error at download time instead of a fabricated key that 404s downstream. Non-contiguous chunk sets are also rejected with an explanation rather than reassembled short.
 - Unchunked downloads no longer issue a `head_object` per file; sizes come from the discovery listing.
 

--- a/README.md
+++ b/README.md
@@ -679,6 +679,15 @@ Two related effects worth knowing:
   provides it, which is roughly 8x faster than the pure-Python one (4.31s vs
   0.50s to parse a 100,000-entry manifest). Nothing to configure; installing
   a PyYAML wheel built with libyaml is enough.
+- **Startup.** boto3 and package metadata load only when a command actually
+  touches S3, cutting the fixed cost of `--help`, `--version` and hooks with
+  nothing to do from ~200ms to ~135ms; what remains is mostly the
+  interpreter itself.
+- **The transfer engine.** `pip install s3lfs[crt]` installs AWS's C-based
+  transfer client (CRT). s3lfs requests it in "auto" mode: it is used where
+  it applies (standard AWS S3 endpoints) and boto3 falls back to the classic
+  client elsewhere -- MinIO, R2 and other S3-compatibles behave exactly as
+  before.
 
 If your manifest is small, none of this matters and a single file is simpler.
 Sharding earns its keep somewhere in the tens of thousands of entries, or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,9 @@ dependencies = [
     "pyyaml>=6.0",
 ]
 
+[project.optional-dependencies]
+crt = ["boto3[crt]"]
+
 [project.scripts]
 s3lfs = "s3lfs.cli:main"
 

--- a/s3lfs/__init__.py
+++ b/s3lfs/__init__.py
@@ -7,17 +7,29 @@ with support for file tracking, parallel operations, encryption, and
 automatic cleanup of unused assets.
 """
 
-from importlib.metadata import PackageNotFoundError
-from importlib.metadata import version as _installed_version
-
-from . import metrics
-from .core import S3LFS
-
-try:
-    # Read the version from installed package metadata so it cannot drift
-    # from pyproject.toml -- there is only one place to bump.
-    __version__ = _installed_version("s3lfs")
-except PackageNotFoundError:  # pragma: no cover - running from a source tree
-    __version__ = "0.0.0+unknown"
-
 __all__ = ["S3LFS", "metrics", "__version__"]
+
+
+def __getattr__(name):
+    # Resolved lazily (PEP 562): importing the package must stay cheap.
+    # Eagerly importing core pulls hashlib/yaml/tqdm, and reading package
+    # metadata costs ~37ms -- costs every `s3lfs --help` would pay.
+    if name == "S3LFS":
+        from .core import S3LFS
+
+        return S3LFS
+    if name == "metrics":
+        # importlib, not `from . import`: the from-import form consults
+        # this very __getattr__ while the submodule is mid-import and
+        # recurses forever.
+        import importlib
+
+        return importlib.import_module("s3lfs.metrics")
+    if name == "__version__":
+        try:
+            from importlib.metadata import PackageNotFoundError, version
+
+            return version("s3lfs")
+        except PackageNotFoundError:  # running from a source tree
+            return "0.0.0+unknown"
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -22,24 +22,19 @@ from pathlib import Path
 from typing import Callable, Optional, Union
 from uuid import uuid4
 
-import boto3
 import portalocker
 import yaml
-from boto3.s3.transfer import TransferConfig
-from botocore import UNSIGNED
-from botocore.config import Config
-from botocore.exceptions import (
-    BotoCoreError,
-    ClientError,
-    NoCredentialsError,
-    PartialCredentialsError,
-)
 from tqdm import tqdm
-from urllib3.exceptions import SSLError
 
 from s3lfs import metrics
 from s3lfs.path_resolver import PathResolver
 from s3lfs.utils import find_git_root
+
+# boto3 and botocore are imported lazily: they cost ~140ms to import, which
+# would be paid by every invocation including --help, --version, and the
+# git hooks that usually have nothing to do. Anything needing an exception
+# class or client resolves it at call time via the helpers below.
+
 
 # Constants
 DEFAULT_CHUNK_SIZE = 5 * 1024 * 1024 * 1024  # 5 GB
@@ -226,8 +221,22 @@ NON_RETRYABLE_S3_CODES = frozenset(
 )
 
 
+def _transient_network_errors():
+    """The exception classes retried on, resolved lazily.
+
+    Referencing these at class-definition time would force the boto3
+    import back onto the startup path that lazy loading just removed.
+    """
+    from botocore.exceptions import BotoCoreError, ClientError
+    from urllib3.exceptions import SSLError
+
+    return (BotoCoreError, ClientError, SSLError)
+
+
 def _is_retryable(exc):
     """Is this exception worth another attempt?"""
+    from botocore.exceptions import ClientError
+
     if isinstance(exc, ClientError):
         code = exc.response.get("Error", {}).get("Code", "")
         if code in NON_RETRYABLE_S3_CODES:
@@ -248,7 +257,9 @@ def retry(times, exceptions, max_delay=30):
     """Retry decorator with exponential backoff and full jitter.
 
     :param times: Maximum number of retry attempts.
-    :param exceptions: Tuple of exception types that trigger a retry.
+    :param exceptions: Exception types that trigger a retry -- a tuple, or
+        a zero-arg callable returning one so decorators need not import
+        the classes eagerly.
     :param max_delay: Cap on the backoff delay in seconds.
     """
 
@@ -258,7 +269,7 @@ def retry(times, exceptions, max_delay=30):
             for attempt in range(times):
                 try:
                     return func(*args, **kwargs)
-                except exceptions as exc:
+                except exceptions() if callable(exceptions) else exceptions as exc:
                     if attempt >= times - 1 or not _is_retryable(exc):
                         raise
                     # Full jitter. Without it, every worker that failed at the
@@ -328,6 +339,10 @@ class S3LFS:
 
         def default_s3_factory(no_sign_request):
             """Default S3 client factory with proper boto3 usage."""
+            import boto3
+            from botocore import UNSIGNED
+            from botocore.config import Config
+
             kwargs = {}
             if self.endpoint_url:
                 kwargs["endpoint_url"] = self.endpoint_url
@@ -358,15 +373,25 @@ class S3LFS:
         # multiply. That is deliberate: a single large asset is one transfer,
         # and dividing the budget across the pool would leave it with no
         # multipart parallelism at all, which is the case s3lfs exists for.
+        from boto3.s3.transfer import TransferConfig
+
         max_concurrency = max(self.workers, DEFAULT_MAX_CONCURRENCY)
+        transfer_kwargs = {"max_concurrency": max_concurrency}
         if no_sign_request:
             # If we're not signing, we can't use multipart. Set the threshold to the max.
+            transfer_kwargs["multipart_threshold"] = DEFAULT_MULTIPART_THRESHOLD
+        try:
+            # Prefer AWS's C-based transfer client (CRT) when the awscrt
+            # package is installed -- install with `pip install s3lfs[crt]`.
+            # "auto" uses it only where it applies (standard AWS S3
+            # endpoints) and falls back to the classic client elsewhere,
+            # e.g. MinIO or R2, so behaviour is unchanged when it cannot
+            # help. Older boto3 without the kwarg lands in the except.
             self.config = TransferConfig(
-                multipart_threshold=DEFAULT_MULTIPART_THRESHOLD,
-                max_concurrency=max_concurrency,
+                preferred_transfer_client="auto", **transfer_kwargs
             )
-        else:
-            self.config = TransferConfig(max_concurrency=max_concurrency)
+        except TypeError:
+            self.config = TransferConfig(**transfer_kwargs)
         self.thread_local = threading.local()
         self.manifest_file = Path(manifest_file)
 
@@ -706,7 +731,7 @@ class S3LFS:
         ever uploaded", which is what push-time verification needs.
         """
 
-        @retry(3, (BotoCoreError, ClientError, SSLError))
+        @retry(3, _transient_network_errors)
         def check(item):
             manifest_key, file_hash = item
             base_key = self._asset_base_key(manifest_key, file_hash)
@@ -734,6 +759,12 @@ class S3LFS:
     def _get_s3_client(self):
         """Ensures each thread gets its own instance of the S3 client with appropriate authentication handling."""
         if not hasattr(self.thread_local, "s3"):
+            from botocore.exceptions import (
+                ClientError,
+                NoCredentialsError,
+                PartialCredentialsError,
+            )
+
             try:
                 self.thread_local.s3 = self.s3_factory(self.no_sign_request)
             except NoCredentialsError:
@@ -2001,7 +2032,7 @@ class S3LFS:
 
         return output_path
 
-    @retry(3, (BotoCoreError, ClientError, SSLError))
+    @retry(3, _transient_network_errors)
     def upload(
         self,
         file_path: Union[str, Path],
@@ -2016,6 +2047,8 @@ class S3LFS:
         if not file_path.exists():
             print(f"Error: {file_path} does not exist.")
             return
+
+        from botocore.exceptions import ClientError
 
         file_hash = self.hash_file(file_path)
         # Use manifest key (relative to git root) for S3 key
@@ -2360,7 +2393,7 @@ class S3LFS:
 
         return (manifest_key, file_hash, chunks)
 
-    @retry(3, (BotoCoreError, ClientError, SSLError))
+    @retry(3, _transient_network_errors)
     def _put_chunk(self, path, s3_key, extra_args):
         """PUT one chunk. Retried, so it must not consume its input."""
         with open(path, "rb") as f:
@@ -2590,7 +2623,7 @@ class S3LFS:
 
         self.parallel_download_chunked(files_to_download, silence=silence)
 
-    @retry(3, (BotoCoreError, ClientError, SSLError))
+    @retry(3, _transient_network_errors)
     def _discover_chunks_for_file(self, manifest_key, file_hash):
         """Discover the stored object(s) for a file, raw or compressed."""
         keys, _sizes, is_chunked, compressed = self._locate_asset(
@@ -2609,7 +2642,7 @@ class S3LFS:
             for i, key in enumerate(keys)
         ]
 
-    @retry(3, (BotoCoreError, ClientError, SSLError))
+    @retry(3, _transient_network_errors)
     def _download_chunk(self, chunk_info, target_path):
         """Download a single S3 chunk to a target path."""
         # See _upload_chunk: queued work must not start after an interrupt.
@@ -2895,6 +2928,12 @@ class S3LFS:
 
         :param silence: If True, suppress success messages.
         """
+        from botocore.exceptions import (
+            ClientError,
+            NoCredentialsError,
+            PartialCredentialsError,
+        )
+
         try:
             # Attempt to list objects in the target bucket with a minimal prefix
             self._get_s3_client().list_objects_v2(
@@ -3769,7 +3808,7 @@ class S3LFS:
                 tracker.end_pipeline()
                 tracker.print_summary(verbose=not silence)
 
-    @retry(3, (BotoCoreError, ClientError, SSLError))
+    @retry(3, _transient_network_errors)
     def download(
         self,
         file_path: Union[str, Path],

--- a/tests/test_cli_coverage.py
+++ b/tests/test_cli_coverage.py
@@ -5,6 +5,8 @@ Tests various error paths, edge cases, and the migrate command.
 
 import json
 import os
+import subprocess
+import sys
 import tempfile
 import unittest
 from pathlib import Path
@@ -564,3 +566,31 @@ class TestCLICoverage(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestStartupStaysLight(unittest.TestCase):
+    """boto3 costs ~140ms to import and package metadata another ~37ms.
+    Neither belongs on the startup path: --help, --version, and hooks with
+    nothing to do would all pay it."""
+
+    def test_importing_the_cli_does_not_import_boto3(self):
+        code = (
+            "import sys; import s3lfs, s3lfs.cli; "
+            "sys.exit(1 if 'boto3' in sys.modules else 0)"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, "importing s3lfs.cli pulled in boto3")
+
+    def test_lazy_package_attributes_still_resolve(self):
+        code = (
+            "import s3lfs; "
+            "assert s3lfs.S3LFS.__name__ == 'S3LFS'; "
+            "assert isinstance(s3lfs.__version__, str); "
+            "import s3lfs.metrics"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True
+        )
+        self.assertEqual(result.returncode, 0, msg=result.stderr)


### PR DESCRIPTION
## Summary

The two levers identified before considering any rewrite: cut the fixed startup cost, and swap the transfer engine where it matters.

## Lazy imports

`python -X importtime` showed where every invocation's ~200ms went: **boto3 at 121ms** and **importlib.metadata at 37ms** (my own `--version` plumbing), both paid by `--help` and by git hooks with nothing to do.

Now deferred to first use: the retry decorator accepts a lazy exception provider, the client factory imports boto3 at call time, and the package `__init__` resolves `S3LFS` / `metrics` / `__version__` via PEP 562.

| | before | after |
|---|---|---|
| `s3lfs --help` | ~200 ms | **~135 ms** |
| module imports on that path | boto3 + metadata + core | core only (~29 ms); remainder is the interpreter |

A regression guard asserts that importing `s3lfs.cli` does not pull in boto3, so the cost can't creep back silently.

One bug worth recording: `from . import metrics` inside a module `__getattr__` recurses infinitely — the from-import form consults that very hook while the submodule is mid-import. `importlib.import_module` is the correct spelling.

## CRT transfer client

`TransferConfig` now requests `preferred_transfer_client="auto"` (with a `TypeError` fallback for older boto3). New extra:

```sh
pip install s3lfs[crt]
```

With `awscrt` installed, transfers to standard AWS S3 endpoints use AWS's C-based engine. Custom endpoints — MinIO, R2, moto — fall back to the classic client, so S3-compatible setups behave exactly as before.

**Honest limitation:** "auto" declines custom endpoints by design, so the CRT gain *cannot be demonstrated against the local mock server* — the benchmark shows no change locally, as expected. Measuring it needs the real bucket that's been offered; `benchmarks/transfer_comparison.py` is ready to run the moment credentials exist.

## Testing

891 passed, 3 skipped; pre-commit clean. New tests: CLI import stays boto3-free; lazy package attributes resolve in a fresh interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)