### PR TITLE
Verify every download end-to-end and fail loudly when one fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A missing stored object is now a loud error at download time instead of a fabricated key that 404s downstream. Non-contiguous chunk sets are also rejected with an explanation rather than reassembled short.
 - Unchunked downloads no longer issue a `head_object` per file; sizes come from the discovery listing.
 
+### Fixed
+- **Downloads of files at or above the multipart threshold failed against S3-compatible backends** (moto, and the same breakage reported for MinIO and R2): boto3 >= 1.36 validates transport-level CRC checksums by default, and those backends return whole-object checksums for ranged GETs. Transport checksums are now requested only where S3 demands them; integrity is enforced end-to-end instead -- every download path now verifies the complete file's SHA-256 against the manifest, including the single-file path, which previously trusted the transport.
+- **A failed download now fails the command.** `checkout --all` and `sync` exited 0 even when files could not be downloaded, reporting the problem only in scrollback; discovery errors were not counted at all. Download failures and never-completed files propagate to a non-zero exit code with a summary.
+
 ### Compatibility
 - Objects stored raw by this version are invisible to older s3lfs clients (they only look for `.gz` keys and will fail loudly at checkout). Teams with mixed versions can set `compression: always` until everyone upgrades. Buckets written by older versions are fully readable -- discovery handles both forms.
 

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -415,7 +415,13 @@ def checkout(
         wanted, skipped = profile.partition(dict(_manifest_files(s3lfs, profile)))
         if skipped:
             click.echo(f"Skipping {len(skipped)} file(s) outside your sparse profile.")
-        s3lfs.parallel_download_all(silence=not verbose, only=set(wanted))
+        failed = s3lfs.parallel_download_all(silence=not verbose, only=set(wanted))
+        if failed:
+            click.echo(
+                f"Error: {failed} file(s) could not be downloaded. The "
+                "working copy is incomplete."
+            )
+            raise SystemExit(1)
     elif manifest_key:
         # MANIFEST GLOB: Find files in manifest and download them
         # The manifest_key is matched against manifest entries (files may not exist on disk)
@@ -563,9 +569,12 @@ def sync(
                 f"No manifest available at {from_revision}; "
                 "falling back to a full checkout."
             )
-        s3lfs.parallel_download_all(
+        failed = s3lfs.parallel_download_all(
             silence=not verbose, only=set(wanted), preserve_modified=not force
         )
+        if failed:
+            click.echo(f"Error: {failed} file(s) could not be downloaded.")
+            raise SystemExit(1)
     else:
         changed = {k: h for k, h in wanted.items() if previous.get(k) != h}
         if not changed and not to_remove:
@@ -607,7 +616,12 @@ def sync(
 
             if to_download:
                 click.echo(f"Downloading {len(to_download)} changed file(s)...")
-                s3lfs.parallel_download_chunked(to_download, silence=not verbose)
+                failed = s3lfs.parallel_download_chunked(
+                    to_download, silence=not verbose
+                )
+                if failed:
+                    click.echo(f"Error: {failed} file(s) could not be downloaded.")
+                    raise SystemExit(1)
             elif not locally_modified:
                 click.echo(f"{len(changed)} changed entr(y/ies) already up-to-date.")
 

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -343,24 +343,40 @@ class S3LFS:
             from botocore import UNSIGNED
             from botocore.config import Config
 
+            # Transport-level (CRC) checksums only where S3 demands them.
+            # boto3 >= 1.36 attaches and validates them by default, which
+            # breaks ranged downloads against S3-compatible backends that
+            # return whole-object checksums for a range (moto, and the same
+            # class of breakage reported for MinIO and R2). s3lfs already
+            # verifies the complete file's SHA-256 against the manifest,
+            # which is end-to-end and strictly stronger than per-request
+            # CRCs. Older botocore without these options lands in except.
+            try:
+                base = Config(
+                    request_checksum_calculation="when_required",
+                    response_checksum_validation="when_required",
+                )
+            except TypeError:
+                base = Config()
+
             kwargs = {}
             if self.endpoint_url:
                 kwargs["endpoint_url"] = self.endpoint_url
             if no_sign_request:
                 if self.use_acceleration:
                     raise RuntimeError(ERROR_MESSAGES["acceleration_not_supported"])
-                config = Config(signature_version=UNSIGNED)
+                config = base.merge(Config(signature_version=UNSIGNED))
                 return boto3.client("s3", config=config, **kwargs)
             else:
                 if self.use_acceleration:
                     # Use transfer acceleration endpoint
                     return boto3.client(
                         "s3",
-                        config=Config(s3={"use_accelerate_endpoint": True}),
+                        config=base.merge(Config(s3={"use_accelerate_endpoint": True})),
                         **kwargs,
                     )
                 else:
-                    return boto3.client("s3", **kwargs)
+                    return boto3.client("s3", config=base, **kwargs)
 
         self.s3_factory = s3_factory if s3_factory is not None else default_s3_factory
 
@@ -2619,9 +2635,9 @@ class S3LFS:
 
         if not files_to_download:
             print("All files are up-to-date.")
-            return
+            return 0
 
-        self.parallel_download_chunked(files_to_download, silence=silence)
+        return self.parallel_download_chunked(files_to_download, silence=silence)
 
     @retry(3, _transient_network_errors)
     def _discover_chunks_for_file(self, manifest_key, file_hash):
@@ -2760,6 +2776,7 @@ class S3LFS:
                             chunks = disc_future.result()
                         except Exception as e:
                             print(f"Error discovering chunks: {e}")
+                            files_failed += 1
                             continue
 
                         mk = chunks[0]["manifest_key"]
@@ -2862,6 +2879,9 @@ class S3LFS:
                     )
                 if len(incomplete) > 10:
                     print(f"  ... and {len(incomplete) - 10} more")
+
+        # Incomplete files were never written; that is a failure too.
+        return files_failed + len(incomplete)
 
     def remove_subtree(self, directory, keep_in_s3=True):
         """
@@ -3938,6 +3958,21 @@ class S3LFS:
             raise
         # The raw path moves the temp file into place, so it is already gone.
         Path(compressed_path).unlink(missing_ok=True)
+
+        # End-to-end verification, same as the parallel path: transport
+        # checksums are off, so this is the check that the bytes on disk
+        # are the bytes the manifest promised.
+        actual_hash = self.hash_file(filesystem_path)
+        if actual_hash != expected_hash:
+            try:
+                os.remove(filesystem_path)
+            except OSError:
+                pass
+            raise RuntimeError(
+                f"Checksum mismatch for {manifest_key}: expected "
+                f"{expected_hash}, got {actual_hash}. The stored object is "
+                "incomplete or corrupt."
+            )
         if not silence:
             print(
                 f"Downloaded {filesystem_path} from "

--- a/tests/test_adaptive_compression.py
+++ b/tests/test_adaptive_compression.py
@@ -222,3 +222,59 @@ class TestLifecycleWithRawObjects(AdaptiveRepoTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestDownloadIntegrity(AdaptiveRepoTestCase):
+    """Transport-level checksums are off (they break ranged downloads on
+    S3-compatible backends); the SHA-256 in the manifest is the integrity
+    check, so it must actually run on every download path -- and a failed
+    download must fail the command."""
+
+    def test_client_requests_checksums_only_when_required(self):
+        s3lfs = S3LFS(bucket_name=TEST_BUCKET, manifest_file=".s3_manifest.yaml")
+        config = s3lfs._get_s3_client().meta.config
+        self.assertEqual(config.response_checksum_validation, "when_required")
+        self.assertEqual(config.request_checksum_calculation, "when_required")
+
+    def test_single_download_rejects_corrupt_object(self):
+        """download() must verify the manifest hash, not trust transport."""
+        Path("photo.jpg").write_bytes(self.raw_bytes)
+        self.runner.invoke(cli, ["track", "photo.jpg"])
+        h = self._manifest_hash("photo.jpg")
+
+        # Corrupt the stored object in place
+        self.s3.put_object(
+            Bucket=TEST_BUCKET, Key=f"pfx/assets/{h}/photo.jpg", Body=b"tampered"
+        )
+        os.remove("photo.jpg")
+
+        s3lfs = S3LFS(bucket_name=TEST_BUCKET, manifest_file=".s3_manifest.yaml")
+        with self.assertRaises(RuntimeError) as caught:
+            s3lfs.download("photo.jpg", silence=True)
+        self.assertIn("Checksum mismatch", str(caught.exception))
+        self.assertFalse(
+            Path("photo.jpg").exists(), "a corrupt file was left looking valid"
+        )
+
+    def test_checkout_all_exits_nonzero_when_content_is_missing(self):
+        """A checkout that could not materialize the working copy must say
+        so in its exit code, not just in scrollback."""
+        Path("photo.jpg").write_bytes(self.raw_bytes)
+        self.runner.invoke(cli, ["track", "photo.jpg"])
+        h = self._manifest_hash("photo.jpg")
+        self.s3.delete_object(Bucket=TEST_BUCKET, Key=f"pfx/assets/{h}/photo.jpg")
+        os.remove("photo.jpg")
+
+        result = self.runner.invoke(cli, ["checkout", "--all"])
+        self.assertNotEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("could not be downloaded", result.output)
+
+    def test_sync_exits_nonzero_when_content_is_missing(self):
+        Path("photo.jpg").write_bytes(self.raw_bytes)
+        self.runner.invoke(cli, ["track", "photo.jpg"])
+        h = self._manifest_hash("photo.jpg")
+        self.s3.delete_object(Bucket=TEST_BUCKET, Key=f"pfx/assets/{h}/photo.jpg")
+        os.remove("photo.jpg")
+
+        result = self.runner.invoke(cli, ["sync"])
+        self.assertNotEqual(result.exit_code, 0, msg=result.output)

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -317,7 +317,16 @@ class TestS3LFSCLIInProcess(unittest.TestCase):
         self.assertEqual(result.exit_code, 0)
 
     def test_checkout_all_with_no_sign_request(self):
-        """Test checkout --all with --no-sign-request."""
+        """--no-sign-request failures must be loud.
+
+        moto forbids anonymous object reads (unsigned GetObject/HeadObject
+        both 403), so an unsigned download can never succeed here -- it
+        never has; earlier versions of this test passed only because
+        download failures were silent. What this asserts now is that the
+        failure reaches the exit code instead of scrollback. The unsigned
+        client configuration itself is covered by the transfer
+        acceleration tests.
+        """
         runner = CliRunner()
         runner.invoke(
             s3lfs_main, ["init", TEST_BUCKET, "test_prefix", "--no-sign-request"]
@@ -326,7 +335,8 @@ class TestS3LFSCLIInProcess(unittest.TestCase):
         os.remove(self.test_file)
 
         result = runner.invoke(s3lfs_main, ["checkout", "--all", "--no-sign-request"])
-        self.assertEqual(result.exit_code, 0)
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("could not be downloaded", result.output)
 
     def test_remove_command(self):
         """Test the remove command."""

--- a/tests/test_reduce_api_calls.py
+++ b/tests/test_reduce_api_calls.py
@@ -1,4 +1,5 @@
 import gzip
+import hashlib
 import os
 import shutil
 import tempfile
@@ -38,10 +39,11 @@ class TestDownloadUsesListSizes(unittest.TestCase):
             mock_boto3.return_value = mock_client
 
             full_data = b"chunked file content here"
+            digest = hashlib.sha256(full_data).hexdigest()
             compressed = gzip.compress(full_data)
             mid = len(compressed) // 2
 
-            s3_key = "pfx/assets/hash1/data.bin.gz"
+            s3_key = f"pfx/assets/{digest}/data.bin.gz"
             mock_client.list_objects_v2.return_value = {
                 "Contents": [
                     {"Key": f"{s3_key}.chunk0", "Size": mid},
@@ -61,7 +63,7 @@ class TestDownloadUsesListSizes(unittest.TestCase):
             mock_client.download_fileobj.side_effect = fake_download
 
             s3lfs = S3LFS(bucket_name="test-bucket")
-            s3lfs.download("data.bin", silence=True, expected_hash="hash1")
+            s3lfs.download("data.bin", silence=True, expected_hash=digest)
 
             # head_object should NOT have been called for chunked files
             mock_client.head_object.assert_not_called()
@@ -87,7 +89,11 @@ class TestDownloadUsesListSizes(unittest.TestCase):
             mock_client.download_fileobj.side_effect = fake_download
 
             s3lfs = S3LFS(bucket_name="test-bucket")
-            s3lfs.download("data.bin", silence=True, expected_hash="hash1")
+            s3lfs.download(
+                "data.bin",
+                silence=True,
+                expected_hash=hashlib.sha256(data).hexdigest(),
+            )
 
             self.assertEqual(mock_client.head_object.call_count, 0)
 

--- a/tests/test_transfer_acceleration.py
+++ b/tests/test_transfer_acceleration.py
@@ -82,18 +82,12 @@ class TestTransferAcceleration(unittest.TestCase):
 
             # Check that the config does not include use_accelerate_endpoint
             # When no config is passed, boto3.client is called without config parameter
-            if "config" in call_args[1]:
-                config = call_args[1]["config"]
-                self.assertFalse(
-                    hasattr(config, "s3")
-                    or (
-                        hasattr(config, "s3")
-                        and "use_accelerate_endpoint" not in config.s3
-                    )
-                )
-            else:
-                # No config passed, which is correct for disabled acceleration
-                pass
+            # A config is always passed now (it carries the transport
+            # checksum settings); what matters is that it does not enable
+            # the accelerate endpoint.
+            config = call_args[1]["config"]
+            s3_options = getattr(config, "s3", None) or {}
+            self.assertFalse(s3_options.get("use_accelerate_endpoint"))
 
     def test_transfer_acceleration_with_unsigned_requests_fails(self):
         """Test that transfer acceleration fails with unsigned requests."""


### PR DESCRIPTION
## Summary

Found by exercising the raw-storage format on the real repository: an 8 MB raw file failed on download with `Expected checksum /lalag== did not match calculated checksum`.

## Three layers

**1. Transport checksums off where not required.** boto3 ≥ 1.36 validates CRC checksums by default, and S3-compatible backends return whole-object checksums for ranged GETs — so any download at or above the multipart threshold failed against moto (verified: default client fails, `when_required` succeeds), with the same breakage widely reported for MinIO and R2. s3lfs's own SHA-256-vs-manifest verification is end-to-end and strictly stronger, so transport CRCs are now requested only where S3 demands them.

**2. …which required closing a verification gap.** The parallel download path verified the manifest hash; the single-file `download()` path trusted the transport and verified nothing. Now every download path hashes the result and deletes a corrupt file rather than leaving it looking valid.

**3. Failures reach the exit code.** `checkout --all` and `sync` exited 0 when files could not be downloaded; discovery errors weren't even counted. All failure classes (discovery, download, finalize, never-completed) now propagate to a non-zero exit with a summary.

## A years-old broken test this exposed

`test_checkout_all_with_no_sign_request` has been green forever while the operation it tests **cannot work**: moto 403s *all* anonymous object reads (verified for both `GetObject` and `HeadObject`), so the unsigned download always failed — silently, with exit 0. The test now asserts the failure is loud, with a comment explaining the moto limitation, rather than pretending the download succeeds.

Also re-validated: the 8 MB real-repo scenario now round-trips with the correct SHA, and the 200 MB benchmark passes with failures now able to fail it.

## Testing

New tests: client config requests checksums `when_required`; single-file download rejects a corrupted object and removes it; `checkout --all` and `sync` exit non-zero when content is missing. 895 passed, 3 skipped; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)