### PR TITLE
Survive write-only credentials, and publish real-S3 benchmark numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Downloads of files at or above the multipart threshold failed against S3-compatible backends** (moto, and the same breakage reported for MinIO and R2): boto3 >= 1.36 validates transport-level CRC checksums by default, and those backends return whole-object checksums for ranged GETs. Transport checksums are now requested only where S3 demands them; integrity is enforced end-to-end instead -- every download path now verifies the complete file's SHA-256 against the manifest, including the single-file path, which previously trusted the transport.
 - **A failed download now fails the command.** `checkout --all` and `sync` exited 0 even when files could not be downloaded, reporting the problem only in scrollback; discovery errors were not counted at all. Download failures and never-completed files propagate to a non-zero exit code with a summary.
 
+### Fixed
+- `s3lfs track` crashed under write-only credentials: the upload path's ETag skip-check uses HeadObject, which requires `s3:GetObject`, and a 403 there aborted the upload. Upload-only policies are a legitimate CI shape; the check now degrades to uploading, whose worst case is re-sending bytes that already exist.
+
 ### Compatibility
 - Objects stored raw by this version are invisible to older s3lfs clients (they only look for `.gz` keys and will fail loudly at checkout). Teams with mixed versions can set `compression: always` until everyone upgrades. Buckets written by older versions are fully readable -- discovery handles both forms.
 

--- a/README.md
+++ b/README.md
@@ -687,7 +687,29 @@ Two related effects worth knowing:
   transfer client (CRT). s3lfs requests it in "auto" mode: it is used where
   it applies (standard AWS S3 endpoints) and boto3 falls back to the classic
   client elsewhere -- MinIO, R2 and other S3-compatibles behave exactly as
-  before.
+  before. Measured against real AWS S3, CRT made no difference for this
+  workload; the remaining gap to raw copy tools is s3lfs's own per-file
+  work, not the HTTP engine.
+
+### Against a raw copy tool, on real S3
+
+Uploading 24 files (201 MB) to AWS S3 us-west-2, versus s5cmd v2.3.0
+(`benchmarks/transfer_comparison.py --upload-only`):
+
+| scenario | s3lfs | s5cmd |
+|---|---|---|
+| cold upload, incompressible data | 3.1s | 2.1s |
+| cold upload, compressible data | **1.0s** | 2.2s |
+| re-run, nothing changed | 0.2s | 0.1s |
+| one file of 24 changed | 0.9s | 0.4s |
+
+On incompressible data s5cmd is ~1.5x faster: it moves bytes and does
+nothing else, while s3lfs also hashes every file (0.5ms/MB -- the price of
+content addressing) and stages a snapshot copy. On compressible data s3lfs
+is ~2x faster, because it sends ~1% of the bytes. Repeat operations are
+sub-second for both. The localhost numbers earlier in this section
+overstate the difference: with a real network under the transfer, the
+fixed per-file costs mostly disappear into it.
 
 If your manifest is small, none of this matters and a single file is simpler.
 Sharding earns its keep somewhere in the tens of thousands of entries, or

--- a/benchmarks/transfer_comparison.py
+++ b/benchmarks/transfer_comparison.py
@@ -85,6 +85,11 @@ def main():
     ap.add_argument("--compressible", action="store_true")
     ap.add_argument("--s5cmd", default="s5cmd")
     ap.add_argument("--prefix", default="bench")
+    ap.add_argument(
+        "--upload-only",
+        action="store_true",
+        help="Skip download scenarios (for write-only credentials)",
+    )
     args = ap.parse_args()
 
     env = dict(os.environ)
@@ -170,41 +175,44 @@ def main():
         )
 
         # --- download ---------------------------------------------------
-        shutil.rmtree(data_dir)
-        results.append(
-            timed(
-                "s3lfs   cold download",
-                lambda: run(s3lfs + ["checkout", "--all"], cwd=root, env=env),
+        if not args.upload_only:
+            shutil.rmtree(data_dir)
+            results.append(
+                timed(
+                    "s3lfs   cold download",
+                    lambda: run(s3lfs + ["checkout", "--all"], cwd=root, env=env),
+                )
             )
-        )
-        results.append(
-            timed(
-                "s3lfs   no-op download",
-                lambda: run(s3lfs + ["checkout", "--all"], cwd=root, env=env),
+            results.append(
+                timed(
+                    "s3lfs   no-op download",
+                    lambda: run(s3lfs + ["checkout", "--all"], cwd=root, env=env),
+                )
             )
-        )
-        out = root / "s5out"
-        out.mkdir(exist_ok=True)
-        results.append(
-            timed(
-                "s5cmd   cold download",
-                lambda: run(
-                    [args.s5cmd] + s5_endpoint + ["cp", dest + "*", str(out)],
-                    cwd=root,
-                    env=env,
-                ),
+            out = root / "s5out"
+            out.mkdir(exist_ok=True)
+            results.append(
+                timed(
+                    "s5cmd   cold download",
+                    lambda: run(
+                        [args.s5cmd] + s5_endpoint + ["cp", dest + "*", str(out)],
+                        cwd=root,
+                        env=env,
+                    ),
+                )
             )
-        )
-        results.append(
-            timed(
-                "s5cmd   no-op download (sync)",
-                lambda: run(
-                    [args.s5cmd] + s5_endpoint + ["sync", dest + "*", str(out) + "/"],
-                    cwd=root,
-                    env=env,
-                ),
+            results.append(
+                timed(
+                    "s5cmd   no-op download (sync)",
+                    lambda: run(
+                        [args.s5cmd]
+                        + s5_endpoint
+                        + ["sync", dest + "*", str(out) + "/"],
+                        cwd=root,
+                        env=env,
+                    ),
+                )
             )
-        )
 
         print(f"{'scenario':38} {'wall clock':>10}   status")
         for label, elapsed, proc in results:

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -2153,7 +2153,18 @@ class S3LFS:
                                 progress_callback(file_size)
                             continue
                     except ClientError as e:
-                        if e.response["Error"]["Code"] != "404":
+                        # 404 means not uploaded yet. Anything else -- most
+                        # commonly 403 from a write-only policy, since
+                        # HeadObject requires s3:GetObject -- means we cannot
+                        # check, and the safe response is to upload anyway:
+                        # worst case is re-sending bytes that were already
+                        # there. Raising here made `track` unusable under
+                        # upload-only credentials, a legitimate CI setup.
+                        if e.response["Error"]["Code"] not in (
+                            "404",
+                            "403",
+                            "AccessDenied",
+                        ):
                             raise
                     with metrics.track("s3_upload", str(path)):
                         with open(path, "rb") as f:

--- a/tests/test_adaptive_compression.py
+++ b/tests/test_adaptive_compression.py
@@ -278,3 +278,27 @@ class TestDownloadIntegrity(AdaptiveRepoTestCase):
 
         result = self.runner.invoke(cli, ["sync"])
         self.assertNotEqual(result.exit_code, 0, msg=result.output)
+
+
+class TestWriteOnlyCredentials(AdaptiveRepoTestCase):
+    def test_upload_survives_denied_head_object(self):
+        """A write-only policy denies HeadObject (it needs s3:GetObject).
+        The ETag skip-check must degrade to uploading, not crash track."""
+        from unittest.mock import patch
+
+        from botocore.exceptions import ClientError
+
+        Path("photo.jpg").write_bytes(self.raw_bytes)
+        s3lfs = S3LFS(bucket_name=TEST_BUCKET, manifest_file=".s3_manifest.yaml")
+        client = s3lfs._get_s3_client()
+        denied = ClientError(
+            {"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadObject"
+        )
+        with patch.object(client, "head_object", side_effect=denied):
+            s3lfs.upload("photo.jpg")
+
+        h = self._manifest_hash("photo.jpg")
+        body = self.s3.get_object(Bucket=TEST_BUCKET, Key=f"pfx/assets/{h}/photo.jpg")[
+            "Body"
+        ].read()
+        self.assertEqual(body, self.raw_bytes)


### PR DESCRIPTION
## Summary

The real-bucket benchmark run, and the bug it found before it could even start.

## The bug

The provided credentials were scoped write-only (`PutObject`/`List`/`Delete`, no `GetObject`) — a legitimate CI shape. `s3lfs track` crashed: the upload path's ETag skip-check calls `HeadObject`, which requires `s3:GetObject`, and the resulting 403 aborted the upload. The check now degrades to uploading — worst case is re-sending bytes that already exist. Tested with a mocked 403.

The harness gains `--upload-only` for such credentials.

## The numbers (real AWS S3, us-west-2, 201 MB, vs s5cmd v2.3.0)

| scenario | s3lfs | s5cmd |
|---|---|---|
| cold upload, incompressible | 3.1s | 2.1s |
| cold upload, **compressible** | **1.0s** | 2.2s |
| re-run, nothing changed | 0.2s | 0.1s |
| one file of 24 changed | 0.9s | 0.4s |

Three findings worth stating plainly:

1. **The localhost numbers overstated the gap badly.** 3–10× locally becomes **1.5×** on a real network — the per-file costs mostly disappear into the transfer.
2. **On compressible data s3lfs wins outright, 2.2×**, because it sends ~1% of the bytes.
3. **CRT made no measurable difference** for this workload (3.16s with, 3.07–3.17s without, across three runs). The remaining gap to s5cmd is s3lfs's own per-file work — hashing (0.5 ms/MB, the price of content addressing) and the staging copy — not the HTTP engine. The staging copy is the next optimization candidate if 1.5× still matters.

Classic-engine repeatability across runs was 3.07/3.17/3.16 — tight enough to trust the comparisons.

All 196 benchmark objects were deleted from the bucket afterward; `s3lfs-bench/` is empty.

## Testing

New test: upload survives a denied HeadObject. 896 passed, 3 skipped; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)