### PR TITLE
Publish the full real-S3 benchmark matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,27 +693,26 @@ Two related effects worth knowing:
 
 ### Against a raw copy tool, on real S3
 
-Uploading 24 files (201 MB) to AWS S3 us-west-2, versus s5cmd v2.3.0
-(`benchmarks/transfer_comparison.py --upload-only`):
+Transferring 24 files (201 MB) to and from AWS S3 us-west-2, versus s5cmd
+v2.3.0 (`benchmarks/transfer_comparison.py`):
 
 | scenario | s3lfs | s5cmd |
 |---|---|---|
-| cold upload, incompressible data | 3.1s | 2.1s |
-| cold upload, compressible data | **1.0s** | 2.2s |
-| re-run, nothing changed | 0.2s | 0.1s |
+| cold upload, incompressible | 3.1s | 2.1s |
+| cold upload, compressible | **0.9s** | 2.0s |
+| cold download, incompressible | 3.7s | 2.1s |
+| cold download, compressible | **1.1s** | 2.3s |
+| re-run, nothing changed (up or down) | 0.2--0.4s | ~0.1s |
 | one file of 24 changed | 0.9s | 0.4s |
 
-On incompressible data s5cmd is ~1.5x faster: it moves bytes and does
-nothing else, while s3lfs also hashes every file (0.5ms/MB -- the price of
-content addressing) and stages a snapshot copy. On compressible data s3lfs
-is ~2x faster, because it sends ~1% of the bytes. Repeat operations are
-sub-second for both. The localhost numbers earlier in this section
-overstate the difference: with a real network under the transfer, the
-fixed per-file costs mostly disappear into it.
-
-If your manifest is small, none of this matters and a single file is simpler.
-Sharding earns its keep somewhere in the tens of thousands of entries, or
-sooner if you commit assets often and care about repository size.
+On incompressible data s5cmd is 1.5--1.8x faster: it moves bytes and does
+nothing else, while s3lfs also hashes every file end-to-end (0.5ms/MB --
+the price of content addressing and the reason a checkout can prove it
+gave you the right bytes) and stages a snapshot copy. On compressible
+data s3lfs is **over 2x faster in both directions**, because it moves
+~1% of the bytes. Repeat operations are sub-second for both. Localhost
+benchmarks overstate the gap several-fold: with a real network under the
+transfer, the per-file costs mostly disappear into it.
 
 ## Correctness
 


### PR DESCRIPTION
## Summary

`s3:GetObject` was granted, so the download half of the benchmark ran. README's comparison table now carries the complete matrix instead of upload-only numbers.

## Real AWS S3, us-west-2, 201 MB, vs s5cmd v2.3.0

| scenario | s3lfs | s5cmd |
|---|---|---|
| cold upload, incompressible | 3.1s | 2.1s |
| cold upload, compressible | **0.9s** | 2.0s |
| cold download, incompressible | 3.7s | 2.1s |
| cold download, compressible | **1.1s** | 2.3s |
| no-ops (either direction) | 0.2–0.4s | ~0.1s |

**On compressible data s3lfs beats s5cmd more than 2× in both directions** — it moves ~1% of the bytes. On incompressible data the gap is 1.5–1.8×, attributable to end-to-end hashing (0.5 ms/MB — what makes a checkout provably correct) and the staging copy. CRT vs classic showed a small real win on downloads (3.7s vs 4.0s) and none on uploads.

All 150 benchmark objects deleted afterward; `s3lfs-bench/` is empty.

## Testing

896 passed, 3 skipped; pre-commit clean. README-only change plus the numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)