### PR TITLE
Cut the staging copy and the post-download re-read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - `s3lfs track` crashed under write-only credentials: the upload path's ETag skip-check uses HeadObject, which requires `s3:GetObject`, and a 403 there aborted the upload. Upload-only policies are a legitimate CI shape; the check now degrades to uploading, whose worst case is re-sending bytes that already exist.
 
+### Changed
+- Raw files at or below the chunk size upload straight from the source instead of staging a temp copy first, halving the disk traffic of a raw upload. A stat snapshot taken before the transfer is compared after it; a file modified mid-upload is refused rather than published torn, and the pipeline never deletes the user's file.
+- Downloads hash the bytes as they stream in, so a sequentially-written file is verified without being read back. boto3 downloads objects above its multipart threshold as out-of-order parallel ranges, where a streaming digest would be garbage -- the writer detects the seeks and falls back to hashing the finished file. Measured on real S3: incompressible cold download 3.7s to 3.2s, upload 3.1s to 3.0s.
+
 ### Compatibility
 - Objects stored raw by this version are invisible to older s3lfs clients (they only look for `.gz` keys and will fail loudly at checkout). Teams with mixed versions can set `compression: always` until everyone upgrades. Buckets written by older versions are fully readable -- discovery handles both forms.
 

--- a/README.md
+++ b/README.md
@@ -698,14 +698,14 @@ v2.3.0 (`benchmarks/transfer_comparison.py`):
 
 | scenario | s3lfs | s5cmd |
 |---|---|---|
-| cold upload, incompressible | 3.1s | 2.1s |
+| cold upload, incompressible | 3.0s | 2.2s |
 | cold upload, compressible | **0.9s** | 2.0s |
-| cold download, incompressible | 3.7s | 2.1s |
+| cold download, incompressible | 3.2s | 2.2s |
 | cold download, compressible | **1.1s** | 2.3s |
 | re-run, nothing changed (up or down) | 0.2--0.4s | ~0.1s |
 | one file of 24 changed | 0.9s | 0.4s |
 
-On incompressible data s5cmd is 1.5--1.8x faster: it moves bytes and does
+On incompressible data s5cmd is 1.4--1.5x faster: it moves bytes and does
 nothing else, while s3lfs also hashes every file end-to-end (0.5ms/MB --
 the price of content addressing and the reason a checkout can prove it
 gave you the right bytes) and stages a snapshot copy. On compressible

--- a/benchmarks/transfer_comparison.py
+++ b/benchmarks/transfer_comparison.py
@@ -85,6 +85,7 @@ def main():
     ap.add_argument("--compressible", action="store_true")
     ap.add_argument("--s5cmd", default="s5cmd")
     ap.add_argument("--prefix", default="bench")
+    ap.add_argument("--workers", type=int, default=None)
     ap.add_argument(
         "--upload-only",
         action="store_true",
@@ -115,6 +116,8 @@ def main():
         init = run(
             s3lfs + ["init", args.bucket, args.prefix] + endpoint, cwd=root, env=env
         )
+        if args.workers:
+            (root / ".s3lfsconfig").write_text(f"workers: {args.workers}\n")
         if init.returncode != 0:
             print("s3lfs init failed:\n" + init.stdout + init.stderr)
             return 1

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -181,6 +181,44 @@ class ShardedFiles(MutableMapping):
         return merged
 
 
+class _HashingWriter:
+    """File-object wrapper that folds every written byte into a SHA-256.
+
+    Hashing during the write means a downloaded file never has to be read
+    back just to verify it -- on a 200MB download that second read was
+    pure overhead.
+
+    Only valid for sequential writes. boto3 downloads objects above its
+    multipart threshold as parallel ranges, seeking and writing out of
+    order; hashing those writes in arrival order produces garbage. Any
+    out-of-order seek therefore invalidates the digest, and hexdigest()
+    returns None so the caller falls back to hashing the finished file.
+    """
+
+    def __init__(self, fileobj):
+        self._file = fileobj
+        self._hasher = hashlib.sha256()
+        self._pos = 0
+        self._sequential = True
+
+    def write(self, data):
+        if self._sequential:
+            self._hasher.update(data)
+            self._pos += len(data)
+        return self._file.write(data)
+
+    def seek(self, offset, whence=0):
+        if not (whence == 0 and offset == self._pos):
+            self._sequential = False
+        return self._file.seek(offset, whence)
+
+    def hexdigest(self):
+        return self._hasher.hexdigest() if self._sequential else None
+
+    def __getattr__(self, name):
+        return getattr(self._file, name)
+
+
 def _default_workers():
     """Compute a sensible default worker count based on available CPUs.
 
@@ -2072,16 +2110,24 @@ class S3LFS:
         stem = self._asset_base_key(manifest_key, file_hash)
 
         extra_args = {"ServerSideEncryption": "AES256"} if self.encryption else {}
+        source_is_user_file = False
+        snapshot = None
         if self._should_compress(file_path):
             s3_key = stem + ".gz"
             compressed_path = self.compress_file(file_path)
         else:
             # Raw storage: the object keeps the file's natural name and
-            # exact bytes. Stage a copy so a concurrent edit cannot change
-            # the content between hashing and upload.
+            # exact bytes. Small enough files upload straight from the
+            # source with a stat-snapshot guard against concurrent edits;
+            # larger ones stage through split_file's temps as before.
             s3_key = stem
-            compressed_path = self.temp_dir / f"{uuid4()}.raw"
-            shutil.copyfile(file_path, compressed_path)
+            if file_path.stat().st_size <= self.chunk_size:
+                snapshot = self._stat_snapshot(file_path)
+                compressed_path = file_path
+                source_is_user_file = True
+            else:
+                compressed_path = self.temp_dir / f"{uuid4()}.raw"
+                shutil.copyfile(file_path, compressed_path)
 
         chunked = False
         if compressed_path.stat().st_size > self.chunk_size:
@@ -2179,17 +2225,25 @@ class S3LFS:
                 if not silence:
                     print(f"{path} uploaded")
             finally:
-                try:
-                    os.remove(path)
-                except OSError:
-                    pass
+                if not source_is_user_file:
+                    try:
+                        os.remove(path)
+                    except OSError:
+                        pass
 
-        if not silence:
-            print(f"Compressed file removed: {compressed_path}")
-        try:
-            os.remove(compressed_path)  # Ensure temp file is deleted
-        except OSError:
-            pass
+        if not source_is_user_file:
+            try:
+                os.remove(compressed_path)  # Ensure temp file is deleted
+            except OSError:
+                pass
+
+        if snapshot is not None and self._stat_snapshot(file_path) != snapshot:
+            # The file changed while streaming out; the stored object may be
+            # torn. Refuse to record it so nothing ever references it.
+            raise RuntimeError(
+                f"{file_path} was modified during upload; run 's3lfs track' "
+                "again to upload the current content."
+            )
 
         # Store file path as key, hash as value
         if needs_immediate_update:
@@ -2341,6 +2395,12 @@ class S3LFS:
         """Upload multiple files with block-level parallelism."""
         self.parallel_upload_chunked(files, silence=silence)
 
+    @staticmethod
+    def _stat_snapshot(path):
+        """(size, mtime_ns, inode) -- cheap identity for change detection."""
+        st = os.stat(path)
+        return (st.st_size, st.st_mtime_ns, getattr(st, "st_ino", None))
+
     def _should_compress(self, file_path):
         """Decide whether compressing this file is worth anything.
 
@@ -2386,10 +2446,29 @@ class S3LFS:
             s3_key = stem + ".gz"
             compressed_path = self.compress_file(file_path)
         else:
-            # Stage a copy so a concurrent edit cannot change the bytes
-            # between hashing and upload -- the same snapshot property the
-            # compressed path gets from writing a temp file.
             s3_key = stem
+            if file_path.stat().st_size <= self.chunk_size:
+                # Upload straight from the source file. Copying 200MB to a
+                # temp file just to read it back doubles the disk traffic of
+                # every raw upload; instead, detect a concurrent edit by
+                # comparing a stat snapshot before and after the transfer
+                # and refuse to publish a torn object.
+                return (
+                    manifest_key,
+                    file_hash,
+                    [
+                        {
+                            "path": file_path,
+                            "s3_key": s3_key,
+                            "chunk_index": 0,
+                            "extra_args": extra_args,
+                            "ephemeral": False,
+                            "snapshot": self._stat_snapshot(file_path),
+                        }
+                    ],
+                )
+            # Chunked raw: split_file writes chunk temps anyway, which are
+            # themselves the snapshot.
             compressed_path = self.temp_dir / f"{uuid4()}.raw"
             shutil.copyfile(file_path, compressed_path)
 
@@ -2443,24 +2522,40 @@ class S3LFS:
         path = chunk_info["path"]
         s3_key = chunk_info["s3_key"]
         extra_args = chunk_info["extra_args"]
+        # Ephemeral paths are temp files this pipeline created and owns.
+        # A non-ephemeral path is the user's own file, uploaded in place --
+        # deleting it would destroy their data.
+        ephemeral = chunk_info.get("ephemeral", True)
 
         # Queued work should not start after an interrupt. Only the drain
         # loops checked this, so every task already submitted to the pool ran
         # to completion and Ctrl-C appeared to hang on large transfers.
         if self._shutdown_requested:
-            try:
-                os.remove(path)
-            except OSError:
-                pass
+            if ephemeral:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
             raise ShutdownRequested(f"Upload cancelled: {s3_key}")
 
         try:
             bytes_uploaded = self._put_chunk(path, s3_key, extra_args)
         finally:
-            try:
-                os.remove(path)
-            except OSError:
-                pass
+            if ephemeral:
+                try:
+                    os.remove(path)
+                except OSError:
+                    pass
+
+        snapshot = chunk_info.get("snapshot")
+        if snapshot is not None and self._stat_snapshot(path) != snapshot:
+            # The file changed while its bytes were streaming out: the
+            # object under this hash may be torn. Refusing here keeps the
+            # entry out of the manifest, so nothing ever references it.
+            raise RuntimeError(
+                f"{path} was modified during upload; run 's3lfs track' "
+                "again to upload the current content."
+            )
 
         return (s3_key, bytes_uploaded)
 
@@ -2677,10 +2772,11 @@ class S3LFS:
             raise ShutdownRequested(f"Download cancelled: {chunk_info['s3_key']}")
 
         with open(target_path, "wb") as f:
+            writer = _HashingWriter(f)
             self._get_s3_client().download_fileobj(
                 Bucket=self.bucket_name,
                 Key=chunk_info["s3_key"],
-                Fileobj=f,
+                Fileobj=writer,
             )
         return (
             chunk_info["manifest_key"],
@@ -2689,6 +2785,7 @@ class S3LFS:
             target_path.stat().st_size,
             chunk_info["is_chunked"],
             chunk_info["num_chunks"],
+            writer.hexdigest(),
         )
 
     def _finalize_file(
@@ -2699,6 +2796,7 @@ class S3LFS:
         expected_hash=None,
         silence=True,
         compressed=True,
+        stream_hash=None,
     ):
         """Merge chunks (if needed) and decompress to final location.
 
@@ -2734,7 +2832,13 @@ class S3LFS:
                 pass
 
         if expected_hash is not None:
-            actual_hash = self.hash_file(filesystem_path)
+            # stream_hash was computed while the bytes were written; a
+            # re-read of the finished file tells us nothing it does not.
+            actual_hash = (
+                stream_hash
+                if stream_hash is not None
+                else self.hash_file(filesystem_path)
+            )
             if actual_hash != expected_hash:
                 # Remove the bad output rather than leave it looking valid.
                 try:
@@ -2819,6 +2923,7 @@ class S3LFS:
                                 bytes_downloaded,
                                 is_chunked,
                                 num_chunks,
+                                stream_digest,
                             ) = dl_future.result()
                         except Exception as e:
                             chunk = dl_futures[dl_future]
@@ -2833,11 +2938,20 @@ class S3LFS:
                         entry = file_tracker.get(manifest_key)
                         if entry is None:
                             continue
-                        entry["received"].append((chunk_index, target_path))
+                        entry["received"].append(
+                            (chunk_index, target_path, stream_digest)
+                        )
 
                         if len(entry["received"]) == entry["expected"]:
                             entry["received"].sort(key=lambda x: x[0])
-                            chunk_paths = [p for _, p in entry["received"]]
+                            chunk_paths = [p for _, p, _ in entry["received"]]
+                            # Raw unchunked: the stream digest IS the file
+                            # hash, so finalize can verify without re-reading.
+                            stream_hash = (
+                                entry["received"][0][2]
+                                if not entry["compressed"] and not entry["is_chunked"]
+                                else None
+                            )
                             try:
                                 self._finalize_file(
                                     manifest_key,
@@ -2846,6 +2960,7 @@ class S3LFS:
                                     expected_hash=entry["file_hash"],
                                     silence=silence,
                                     compressed=entry["compressed"],
+                                    stream_hash=stream_hash,
                                 )
                                 files_finalized += 1
                             except Exception as e:
@@ -2871,7 +2986,7 @@ class S3LFS:
                 if len(e["received"]) != e["expected"]
             )
             for mk in incomplete:
-                for _, path in file_tracker[mk]["received"]:
+                for _, path, _ in file_tracker[mk]["received"]:
                     try:
                         os.remove(path)
                     except OSError:
@@ -3893,6 +4008,7 @@ class S3LFS:
         os.makedirs(base_directory, exist_ok=True)
 
         target_paths = []
+        stream_digests: list = []
         total_file_size = sum(key_sizes.values())
 
         if progress_callback:
@@ -3940,12 +4056,14 @@ class S3LFS:
                         print(f"Downloading {key} to {target_path}")
                     with metrics.track("s3_download", key):
                         with open(target_path, "wb") as f:
+                            writer = _HashingWriter(f)
                             self._get_s3_client().download_fileobj(
                                 Bucket=self.bucket_name,
                                 Key=key,
-                                Fileobj=f,
+                                Fileobj=writer,
                                 Callback=download_callback,
                             )
+                            stream_digests.append(writer.hexdigest())
             except Exception as e:
                 print(f"Error downloading {key}: {e}")
 
@@ -3972,8 +4090,18 @@ class S3LFS:
 
         # End-to-end verification, same as the parallel path: transport
         # checksums are off, so this is the check that the bytes on disk
-        # are the bytes the manifest promised.
-        actual_hash = self.hash_file(filesystem_path)
+        # are the bytes the manifest promised. For a raw single object the
+        # digest was computed as the bytes streamed in, so the file need
+        # not be read back.
+        if (
+            not compressed
+            and not is_chunked
+            and len(stream_digests) == 1
+            and stream_digests[0] is not None
+        ):
+            actual_hash = stream_digests[0]
+        else:
+            actual_hash = self.hash_file(filesystem_path)
         if actual_hash != expected_hash:
             try:
                 os.remove(filesystem_path)

--- a/tests/test_adaptive_compression.py
+++ b/tests/test_adaptive_compression.py
@@ -302,3 +302,81 @@ class TestWriteOnlyCredentials(AdaptiveRepoTestCase):
             "Body"
         ].read()
         self.assertEqual(body, self.raw_bytes)
+
+
+class TestDirectSourceUpload(AdaptiveRepoTestCase):
+    """Raw files upload straight from the source (no staging copy), which
+    makes two properties safety-critical: the pipeline must never delete
+    the user's file, and a file modified mid-upload must not be published."""
+
+    def test_source_file_survives_upload(self):
+        Path("photo.jpg").write_bytes(self.raw_bytes)
+        result = self.runner.invoke(cli, ["track", "photo.jpg"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertTrue(Path("photo.jpg").exists(), "upload deleted the source file")
+        self.assertEqual(Path("photo.jpg").read_bytes(), self.raw_bytes)
+
+    def test_modification_during_upload_is_refused(self):
+        Path("photo.jpg").write_bytes(self.raw_bytes)
+        s3lfs = S3LFS(bucket_name=TEST_BUCKET, manifest_file=".s3_manifest.yaml")
+
+        real_put = s3lfs._put_chunk
+
+        def mutate_then_put(path, s3_key, extra_args):
+            n = real_put(path, s3_key, extra_args)
+            # Simulate an edit landing while bytes streamed out
+            Path("photo.jpg").write_bytes(b"edited mid-flight")
+            return n
+
+        from unittest.mock import patch
+
+        with patch.object(s3lfs, "_put_chunk", side_effect=mutate_then_put):
+            s3lfs.parallel_upload(["photo.jpg"])
+
+        manifest = yaml.safe_load(Path(".s3_manifest.yaml").read_text())
+        self.assertNotIn(
+            "photo.jpg",
+            manifest.get("files") or {},
+            "a torn upload was recorded in the manifest",
+        )
+
+
+class TestHashingWriterOrdering(unittest.TestCase):
+    """boto3 downloads objects above its multipart threshold as parallel
+    ranges, seeking and writing out of order. Hashing those writes in
+    arrival order produces garbage, so the digest must invalidate itself
+    rather than reject a perfectly good file -- which is exactly what
+    happened against real S3 with 9MB objects."""
+
+    def test_sequential_writes_produce_the_digest(self):
+        import io
+
+        from s3lfs.core import _HashingWriter
+
+        w = _HashingWriter(io.BytesIO())
+        w.write(b"hello ")
+        w.write(b"world")
+        self.assertEqual(w.hexdigest(), hashlib.sha256(b"hello world").hexdigest())
+
+    def test_out_of_order_seek_invalidates_the_digest(self):
+        import io
+
+        from s3lfs.core import _HashingWriter
+
+        w = _HashingWriter(io.BytesIO())
+        w.seek(4096)  # ranged download writes a later part first
+        w.write(b"tail")
+        w.seek(0)
+        w.write(b"head")
+        self.assertIsNone(w.hexdigest())
+
+    def test_seek_to_current_position_is_still_sequential(self):
+        import io
+
+        from s3lfs.core import _HashingWriter
+
+        w = _HashingWriter(io.BytesIO())
+        w.write(b"abc")
+        w.seek(3)  # no-op seek, some writers do this
+        w.write(b"def")
+        self.assertEqual(w.hexdigest(), hashlib.sha256(b"abcdef").hexdigest())

--- a/tests/test_block_parallel.py
+++ b/tests/test_block_parallel.py
@@ -147,7 +147,7 @@ class TestDownloadChunk(unittest.TestCase):
                 "num_chunks": 1,
             }
 
-            mk, idx, path, size, is_chunked, num = s3lfs._download_chunk(
+            mk, idx, path, size, is_chunked, num, digest = s3lfs._download_chunk(
                 chunk_info, target
             )
 
@@ -181,7 +181,7 @@ class TestDownloadChunk(unittest.TestCase):
                 "num_chunks": 1,
             }
 
-            _, _, _, size, _, _ = s3lfs._download_chunk(chunk_info, target)
+            _, _, _, size, _, _, _ = s3lfs._download_chunk(chunk_info, target)
             self.assertEqual(size, 1024)
 
 


### PR DESCRIPTION
## Summary

"Maximize competitiveness": the measured levers, in order of what the data ruled out first — CRT changed nothing, workers=32 changed little, so the remaining gap was s3lfs's own per-file pipeline. Two structural costs removed.

## Upload: no more staging copy

Raw files ≤ chunk size upload **straight from the source**. Previously every raw upload copied the file to a temp first (snapshot semantics), doubling disk traffic. Two properties keep direct upload safe, both tested:

- The pipeline marks its own temp files `ephemeral` and **never deletes the user's file** — the naive version of this change would have `os.remove`'d source files in two places.
- A stat snapshot (size, mtime_ns, inode) taken before the transfer is compared after it. A file modified mid-upload is **refused and kept out of the manifest**, so nothing ever references a torn object.

## Download: hash while writing

Every downloaded byte folds into a SHA-256 as it streams in, so a sequentially-written file verifies against the manifest without being read back — previously a 200 MB download was followed by a 200 MB read purely to check it.

**The trap this fell into, caught by benchmarking against real S3:** boto3 downloads objects above its multipart threshold as parallel ranges, seeking and writing out of order. A streaming digest of those writes is garbage, and the first version rejected perfectly good 9 MB files (safe direction — good files refused, nothing corrupt accepted — but broken). The writer now detects out-of-order seeks, invalidates its digest, and falls back to hashing the finished file. Three unit tests pin the ordering semantics, including the no-op-seek case.

## Measured, real S3 (24 × 8 MB incompressible, us-west-2)

| | before | after | s5cmd |
|---|---|---|---|
| cold upload | 3.1s | **3.0s** | 2.2s |
| cold download | 3.7–4.0s | **3.2s** | 2.2s |

Gap narrows to 1.4–1.5×. What remains is end-to-end hashing (0.5 ms/MB — the product) and per-request overhead. Compressible data was already a 2× win in both directions and is unchanged.

All benchmark objects deleted; `s3lfs-bench/` is empty.

## Testing

New tests: source file survives upload, mid-upload modification refused, and the three `_HashingWriter` ordering cases. 901 passed, 3 skipped; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)