### PR TITLE
Add s3lfs doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `s3lfs doctor`: one command that checks the whole integration -- manifest health, shard visibility under sparse checkouts, every hook, the merge driver, PATH visibility for hooks, and live S3 permissions probed operation-by-operation -- and prints the fix for each finding. This project's characteristic failure mode is a component that fails quietly; doctor makes those loud on demand.
+
 ## [0.6.0] - 2026-08-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -169,6 +169,12 @@ Reachability is computed on path *and* content hash, matching the storage layout
 s3lfs cleanup --force                    # Clean up without confirmation
 ```
 
+### Diagnose the Setup
+```sh
+s3lfs doctor
+```
+**Description**: Checks that every part of the integration is actually wired up -- git repo, manifest (and shard visibility under a sparse checkout), each git hook, the merge driver, whether hooks can find `s3lfs` on PATH, and live S3 permissions (list/write/read/delete probed individually, so a write-only CI key is diagnosed precisely). Exits non-zero on blocking problems and prints the command that fixes each finding.
+
 ### Verify Uploaded Content
 ```sh
 s3lfs verify

--- a/s3lfs/cli.py
+++ b/s3lfs/cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -2355,6 +2356,175 @@ def sparse(porcelain):
         "materialized here."
     )
     click.echo("Run 's3lfs sync' after changing the patterns.")
+
+
+@cli.command()
+@click.option("--no-sign-request", is_flag=True, help="Use unsigned S3 requests")
+@click.option(
+    "--endpoint-url",
+    default=None,
+    help="Custom S3 endpoint URL for S3-compatible storage",
+)
+def doctor(no_sign_request, endpoint_url):
+    """Check that every part of the integration is actually wired up.
+
+    s3lfs depends on parts that fail quietly: hooks that never fire, a
+    merge driver nobody registered, credentials that allow some operations
+    and not others, a sparse checkout hiding the manifest. This checks each
+    one and says what to run to fix it.
+    """
+    failures = 0
+    warnings = 0
+
+    def ok(msg):
+        click.echo(f"  ok       {msg}")
+
+    def warn(msg, fix=None):
+        nonlocal warnings
+        warnings += 1
+        click.echo(f"  WARN     {msg}")
+        if fix:
+            click.echo(f"           fix: {fix}")
+
+    def fail(msg, fix=None):
+        nonlocal failures
+        failures += 1
+        click.echo(f"  FAIL     {msg}")
+        if fix:
+            click.echo(f"           fix: {fix}")
+
+    # --- git ------------------------------------------------------------
+    git_root = find_git_root()
+    if not git_root:
+        fail("not inside a git repository", "run from a repo, or git init")
+        raise SystemExit(1)
+    ok(f"git repository at {git_root}")
+
+    # --- manifest -------------------------------------------------------
+    manifest_path = get_manifest_path(git_root)
+    if not manifest_path.exists():
+        fail("s3lfs is not initialized", "s3lfs init <bucket> <prefix>")
+        raise SystemExit(1)
+    try:
+        s3lfs = _make_s3lfs(
+            git_root,
+            manifest_path,
+            no_sign_request=no_sign_request,
+            endpoint_url=endpoint_url,
+        )
+    except Exception as e:
+        fail(f"manifest cannot be read: {e}")
+        raise SystemExit(1)
+    entries = len(s3lfs.manifest.get("files", {}))
+    sharded = " (sharded)" if s3lfs.is_sharded else ""
+    ok(f"manifest {manifest_path.name}{sharded}: {entries} tracked file(s)")
+
+    if s3lfs.is_sharded and _shards_are_hidden(git_root):
+        fail(
+            "manifest shards are hidden by the sparse checkout",
+            f"git sparse-checkout add {MANIFEST_SHARD_DIR}",
+        )
+
+    from s3lfs.core import USING_LIBYAML
+
+    if USING_LIBYAML:
+        ok("libyaml-backed YAML parser (fast)")
+    else:
+        warn(
+            "pure-Python YAML parser: manifest operations are ~8x slower",
+            "install a PyYAML wheel built with libyaml",
+        )
+
+    # --- hooks ----------------------------------------------------------
+    hooks_dir = _get_hooks_dir(git_root)
+    for hook_name in HOOK_SCRIPTS:
+        hook_path = hooks_dir / hook_name
+        if not hook_path.exists() or S3LFS_HOOK_START not in _read_text_or_empty(
+            hook_path
+        ):
+            warn(f"{hook_name} hook not installed", "s3lfs install")
+        else:
+            ok(f"{hook_name} hook installed")
+
+    driver = subprocess.run(
+        ["git", "config", "merge.s3lfs.driver"],
+        capture_output=True,
+        text=True,
+        cwd=str(git_root),
+    )
+    if driver.returncode == 0 and driver.stdout.strip():
+        ok("manifest merge driver registered")
+    else:
+        warn(
+            "manifest merge driver not registered: concurrent manifest "
+            "changes will conflict",
+            "s3lfs install",
+        )
+
+    if shutil.which("s3lfs"):
+        ok("s3lfs is on PATH (hooks can find it)")
+    else:
+        warn(
+            "s3lfs is not on PATH: hooks invoked by git will do nothing",
+            "install s3lfs where git's environment can see it",
+        )
+
+    # --- sparse ---------------------------------------------------------
+    profile = SparseProfile.detect(git_root)
+    if profile.degraded_reason:
+        warn(profile.degraded_reason)
+    elif profile.active:
+        ok("sparse checkout active; s3lfs applies its rules")
+
+    # --- S3 -------------------------------------------------------------
+    probe_key = f"{s3lfs.repo_prefix}/.s3lfs-doctor-probe"
+    client = s3lfs._get_s3_client()
+
+    def s3_probe(name, fn, fix=None):
+        try:
+            fn()
+            ok(f"S3 {name}")
+            return True
+        except Exception as e:
+            code = getattr(e, "response", {}).get("Error", {}).get("Code", "")
+            fail(f"S3 {name}: {code or e}", fix)
+            return False
+
+    s3_probe(
+        f"list s3://{s3lfs.bucket_name}",
+        lambda: client.list_objects_v2(
+            Bucket=s3lfs.bucket_name, Prefix=s3lfs.repo_prefix, MaxKeys=1
+        ),
+        "check credentials and s3:ListBucket permission",
+    )
+    wrote = s3_probe(
+        "write",
+        lambda: client.put_object(
+            Bucket=s3lfs.bucket_name, Key=probe_key, Body=b"doctor"
+        ),
+        "uploads need s3:PutObject",
+    )
+    if wrote:
+        s3_probe(
+            "read",
+            lambda: client.get_object(Bucket=s3lfs.bucket_name, Key=probe_key),
+            "downloads need s3:GetObject; uploads still work without it",
+        )
+        s3_probe(
+            "delete",
+            lambda: client.delete_object(Bucket=s3lfs.bucket_name, Key=probe_key),
+            "cleanup needs s3:DeleteObject",
+        )
+
+    # --- summary --------------------------------------------------------
+    click.echo()
+    if failures:
+        click.echo(f"{failures} problem(s), {warnings} warning(s).")
+        raise SystemExit(1)
+    if warnings:
+        click.echo(f"No blocking problems; {warnings} warning(s).")
+    else:
+        click.echo("Everything is wired up.")
 
 
 @click.command("merge-driver")

--- a/tests/test_git_integration.py
+++ b/tests/test_git_integration.py
@@ -1583,3 +1583,40 @@ class TestHookQuietness(GitRepoTestCase):
 
         result = self.runner.invoke(cli, ["track", "--modified", "--verbose"])
         self.assertIn("Checking", result.output)
+
+
+class TestDoctor(GitRepoTestCase):
+    """doctor exists because this project's failure mode is components
+    that fail quietly: hooks that never fire, drivers nobody registered,
+    credentials that allow some operations and not others."""
+
+    def test_healthy_repo_reports_wired_up(self):
+        self.runner.invoke(cli, ["install"])
+        result = self.runner.invoke(cli, ["doctor"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("manifest merge driver registered", result.output)
+        self.assertIn("S3 list", result.output)
+        self.assertIn("S3 write", result.output)
+
+    def test_missing_hooks_are_warnings_not_failures(self):
+        result = self.runner.invoke(cli, ["doctor"])
+        self.assertEqual(result.exit_code, 0, msg=result.output)
+        self.assertIn("hook not installed", result.output)
+        self.assertIn("s3lfs install", result.output)
+
+    def test_unreachable_bucket_is_a_failure(self):
+        import yaml as _yaml
+
+        m = _yaml.safe_load(Path(".s3_manifest.yaml").read_text())
+        m["bucket_name"] = "no-such-bucket-doctor-test"
+        Path(".s3_manifest.yaml").write_text(_yaml.safe_dump(m))
+
+        result = self.runner.invoke(cli, ["doctor"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("FAIL", result.output)
+
+    def test_uninitialized_repo_says_how_to_start(self):
+        Path(".s3_manifest.yaml").unlink()
+        result = self.runner.invoke(cli, ["doctor"])
+        self.assertNotEqual(result.exit_code, 0)
+        self.assertIn("s3lfs init", result.output)


### PR DESCRIPTION
## Summary

Every serious bug this project has had shares a shape: **a component that fails quietly.** Hooks appended after `exit 0` that never ran; a merge driver nobody registered; `s3lfs` missing from the PATH git hooks see; manifest shards hidden by a sparse checkout; credentials that allow uploads but not the `HeadObject` the upload path used; checkouts that failed with exit 0.

`s3lfs doctor` checks all of it in one command:

```
  ok       git repository at /repo
  ok       manifest .s3_manifest.yaml (sharded): 87 tracked file(s)
  ok       libyaml-backed YAML parser (fast)
  ok       pre-commit hook installed
  WARN     manifest merge driver not registered: concurrent manifest changes will conflict
           fix: s3lfs install
  ok       s3lfs is on PATH (hooks can find it)
  ok       S3 list s3://kjmatzen
  ok       S3 write
  FAIL     S3 read: AccessDenied
           fix: downloads need s3:GetObject; uploads still work without it
```

Permissions are probed operation-by-operation — list, write, read, delete — so a write-only CI key (the exact setup that crashed `track` last week) is diagnosed precisely rather than as a vague failure. Exits non-zero on blocking problems; warnings don't block.

## Testing

Four tests: healthy repo, missing hooks as warnings, unreachable bucket as failure, uninitialized repo pointing at `s3lfs init`. 905 passed, 3 skipped; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)