### PR TITLE
Validate CLI hash output instead of trusting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `sha256sum`/`md5sum` output is now validated before use. GNU coreutils prefixes the whole line with a backslash when the filename needed escaping -- which every Windows path does, and any POSIX path containing a backslash or newline would too. That byte became part of the hash, the corrupt hash became an S3 key, and every downstream checksum comparison failed. Output that does not parse as a digest now falls back to Python hashing. Found by running the suite on Windows for the first time, where this one bug accounted for 53 of 71 failures.
+
 ### Added
 - `s3lfs doctor`: one command that checks the whole integration -- manifest health, shard visibility under sparse checkouts, every hook, the merge driver, PATH visibility for hooks, and live S3 permissions probed operation-by-operation -- and prints the fix for each finding. This project's characteristic failure mode is a component that fails quietly; doctor makes those loud on demand.
 

--- a/s3lfs/core.py
+++ b/s3lfs/core.py
@@ -1809,7 +1809,7 @@ class S3LFS:
 
     def _hash_file_cli(self, file_path):
         """
-        Compute the SHA-256 hash using the `sha256sum` CLI utility (POSIX only).
+        Compute the SHA-256 hash using the `sha256sum` CLI utility.
         """
         result = subprocess.run(
             ["sha256sum", str(file_path)],
@@ -1817,7 +1817,16 @@ class S3LFS:
             text=True,
             check=True,
         )
-        return result.stdout.split()[0]  # Extract the hash from the output
+        # GNU coreutils prefixes the whole line with a backslash when the
+        # filename needed escaping -- which every Windows path does, since
+        # backslash is its separator. Taking that byte as part of the hash
+        # produced 65-character "hashes", which became S3 keys, which then
+        # failed every checksum comparison downstream.
+        digest = result.stdout.split()[0].lstrip("\\").lower()
+        if len(digest) != 64 or any(c not in "0123456789abcdef" for c in digest):
+            # Unparseable tool output must not become an object key.
+            return self._hash_file_mmap(file_path)
+        return digest
 
     def md5_file(self, file_path: Union[str, Path], method: str = "auto") -> str:
         """
@@ -1891,7 +1900,11 @@ class S3LFS:
                 text=True,
                 check=True,
             )
-            return result.stdout.split()[0]  # Extract the hash from the output
+            # Same coreutils backslash-escape prefix as sha256sum.
+            digest = result.stdout.split()[0].lstrip("\\").lower()
+            if len(digest) != 32 or any(c not in "0123456789abcdef" for c in digest):
+                return self._md5_file_mmap(file_path)
+            return digest
         elif sys.platform.startswith("darwin") and shutil.which("md5"):
             # macOS: use md5 -r (for raw output similar to md5sum)
             result = subprocess.run(

--- a/tests/test_error_handling_and_edge_cases.py
+++ b/tests/test_error_handling_and_edge_cases.py
@@ -154,10 +154,15 @@ class TestS3LFSErrorHandlingAndEdgeCases(unittest.TestCase):
         mock_which.return_value = "/usr/bin/sha256sum"
 
         with patch("subprocess.run") as mock_run:
-            mock_run.return_value.stdout = "abc123def456 /path/to/file\n"
+            # A real-shaped digest: output that does not parse as one now
+            # falls back to Python hashing rather than becoming an S3 key.
+            mock_run.return_value.stdout = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa /path/to/file\n"
 
             result = self.versioner.hash_file(self.test_file, method="cli")
-            self.assertEqual(result, "abc123def456")
+            self.assertEqual(
+                result,
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )
 
             mock_run.assert_called_once()
             args = mock_run.call_args[0][0]
@@ -852,11 +857,16 @@ class TestS3LFSErrorHandlingAndEdgeCases(unittest.TestCase):
             patch("shutil.which", return_value="/usr/bin/sha256sum"),
             patch("subprocess.run") as mock_run,
         ):
-            mock_run.return_value.stdout = "abc123def456 /path/to/file\n"
+            # A real-shaped digest: output that does not parse as one now
+            # falls back to Python hashing rather than becoming an S3 key.
+            mock_run.return_value.stdout = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa /path/to/file\n"
 
             # Should select CLI method for non-empty files on Linux
             result = self.versioner.hash_file(self.test_file, method="auto")
-            self.assertEqual(result, "abc123def456")
+            self.assertEqual(
+                result,
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )
 
     def test_md5_file_auto_selection_linux(self):
         """Test MD5 auto selection on Linux."""

--- a/tests/test_s3lfs.py
+++ b/tests/test_s3lfs.py
@@ -3666,3 +3666,35 @@ class TestChunkListingPagination(unittest.TestCase):
 
         self.assertEqual(s3lfs._list_keys("prefix"), [])
         self.assertEqual(client.list_objects_v2.call_count, 1)
+
+
+class TestCoreutilsEscapedHashOutput(unittest.TestCase):
+    """GNU coreutils prefixes sha256sum output with a backslash when the
+    filename needed escaping -- which every Windows path does. Taking that
+    byte as part of the hash produced 65-character hashes that became S3
+    keys and failed every downstream checksum comparison."""
+
+    def _s3lfs(self):
+        return S3LFS.__new__(S3LFS)
+
+    def test_backslash_prefixed_output_is_parsed(self):
+        from unittest.mock import MagicMock, patch
+
+        s3lfs = self._s3lfs()
+        digest = "a" * 64
+        fake = MagicMock()
+        fake.stdout = f"\\{digest}  C:\\\\repo\\\\file.bin\n"
+        with patch("s3lfs.core.subprocess.run", return_value=fake):
+            self.assertEqual(s3lfs._hash_file_cli("file.bin"), digest)
+
+    def test_garbage_output_falls_back_to_python_hashing(self):
+        from unittest.mock import MagicMock, patch
+
+        s3lfs = self._s3lfs()
+        fake = MagicMock()
+        fake.stdout = "not-a-hash file.bin\n"
+        with (
+            patch("s3lfs.core.subprocess.run", return_value=fake),
+            patch.object(S3LFS, "_hash_file_mmap", return_value="b" * 64),
+        ):
+            self.assertEqual(s3lfs._hash_file_cli("file.bin"), "b" * 64)


### PR DESCRIPTION
## Summary

Found by running the test suite on **Windows for the first time** (draft probe #136): 71 failures, of which **53 traced to this single bug**.

GNU coreutils prefixes `sha256sum`/`md5sum` output with a backslash when the filename needed escaping:

```
\aaaa...aaaa  C:\repo\file.bin      ← every Windows path triggers this
```

s3lfs took `\aaaa...` as the hash. The 65-character "hash" became an S3 key, and every downstream checksum comparison failed. Not Windows-only in principle: any POSIX path containing a backslash or newline gets the same escaping.

The digest is now stripped of the escape prefix and validated as exactly 64 (or 32) hex characters — anything unparseable falls back to Python hashing rather than becoming an object key.

## Windows status after this fix

18 failures remain on the probe, almost all test-infrastructure (tests invoking `/bin/sh` literally, Unix exec-bit assertions, POSIX path-string comparisons) plus two path-resolution cases worth a look. Filed as an issue with the categorized list; the probe PR is closed unmerged.

## Testing

Two regression tests (backslash-prefixed output parsed; garbage output falls back), plus fixture updates where tests stubbed 12-character "hashes" that validation now rightly rejects. 907 passed, 3 skipped; pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)