### PR TITLE
Release 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.2] - 2026-08-09
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3lfs"
-version = "0.6.1"
+version = "0.6.2"
 description = "A Python-based version control system for large assets using Amazon S3."
 authors = [{name = "Kevin Blackburn-Matzen", email = "kmatzen@gmail.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump. Contents: `encryption: false` in `.s3lfsconfig` (#140 — the CLI could not disable SSE, making it unusable against MinIO without KMS), doctor's write probe sending real upload headers (#141), and the benchmark CI job with dated README tables (#140).

🤖 Generated with [Claude Code](https://claude.com/claude-code)