### PR TITLE
Run the test suite on Windows and fix what it found

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,14 +33,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The floor and the ceiling of the supported range on Linux, plus a
-        # macOS run: s3lfs shells out to git constantly and writes /bin/sh
-        # hooks, so a second platform is worth more than a third minor
-        # version.
+        # The floor and the ceiling of the supported range on Linux, plus
+        # macOS and Windows runs: s3lfs shells out to git constantly and
+        # writes sh hooks, so more platforms are worth more than more
+        # minor versions. Windows exercises the drive-letter and
+        # path-separator edge cases POSIX cannot.
         os: [ubuntu-latest]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: macos-latest
+            python-version: "3.13"
+          - os: windows-latest
             python-version: "3.13"
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- **Manifest keys can no longer escape the repository root on Windows.**
+  `to_filesystem_path` trusted `os.path.isabs`, but since Python 3.13 a
+  rooted key like `/foo` is not "absolute" on Windows -- and pathlib's
+  join replaces the base with it, resolving to `C:/foo`, outside the
+  repo. Keys with embedded `..` segments got past the prefix check on
+  every platform. Resolved paths are now verified to stay inside the
+  repository.
+- **Subdirectory context works from Windows 8.3 short paths.**
+  `PathResolver` resolved an explicitly passed working directory but not
+  the `Path.cwd()` default, so a shell sitting in a short path
+  (`C:\Users\RUNNER~1\...`) never matched the resolved git root and
+  subdirectory prefixing silently turned off.
+
+### Added
+
+- **Windows is now tested in CI** (`windows-latest`, Python 3.13). The
+  remaining test-suite failures from #138 were POSIX assumptions in the
+  tests themselves -- hardcoded `/bin/sh`, `:` as the PATH separator,
+  exec-bit assertions, driveless absolute fixtures -- and are fixed or
+  skipped where the concept does not exist on Windows.
+
 ## [0.6.2] - 2026-08-09
 
 ### Fixed

--- a/s3lfs/path_resolver.py
+++ b/s3lfs/path_resolver.py
@@ -96,8 +96,19 @@ class PathResolver:
         if manifest_key.startswith(".."):
             raise ValueError(f"Manifest key cannot escape git root: {manifest_key}")
 
-        # Convert POSIX path to platform-specific path and make absolute
-        return (self.git_root / manifest_key).resolve()
+        # Convert POSIX path to platform-specific path and make absolute.
+        # The containment check below is load-bearing, not belt-and-braces:
+        # manifest keys come from manifests, which arrive with a clone. On
+        # Windows a rooted key like "/foo" passes isabs() (False since
+        # Python 3.13) and then pathlib's join REPLACES the base, yielding
+        # C:/foo -- outside the repository. Embedded ".." segments get past
+        # the prefix check on every platform.
+        resolved = (self.git_root / manifest_key).resolve()
+        try:
+            resolved.relative_to(self.git_root)
+        except ValueError:
+            raise ValueError(f"Manifest key cannot escape git root: {manifest_key}")
+        return resolved
 
     def from_cli_input(
         self, cli_path: str, cwd: Optional[Path] = None, allow_absolute: bool = False
@@ -129,10 +140,10 @@ class PathResolver:
             >>> resolver.from_cli_input("subdir/file.txt", Path("/repo"))
             'subdir/file.txt'
         """
-        if cwd is None:
-            cwd = Path.cwd()
-        else:
-            cwd = Path(cwd).resolve()
+        # Resolve the default too: on Windows, Path.cwd() can be an 8.3
+        # short path (RUNNER~1) that never string-matches the resolved
+        # git_root, silently disabling subdirectory prefixing.
+        cwd = (Path(cwd) if cwd is not None else Path.cwd()).resolve()
 
         cli_path_obj = Path(cli_path)
 
@@ -221,10 +232,10 @@ class PathResolver:
         :param cwd: Current working directory (defaults to Path.cwd())
         :return: CWD relative to git root, or Path(".") if outside repo
         """
-        if cwd is None:
-            cwd = Path.cwd()
-        else:
-            cwd = Path(cwd).resolve()
+        # Resolved for the same reason as in from_cli_input: an unresolved
+        # default cwd (Windows short paths, macOS /tmp symlinks) falls into
+        # the except branch and reports git root for every subdirectory.
+        cwd = (Path(cwd) if cwd is not None else Path.cwd()).resolve()
 
         try:
             return cwd.relative_to(self.git_root)

--- a/tests/test_cli_integration.py
+++ b/tests/test_cli_integration.py
@@ -99,12 +99,13 @@ class TestS3LFSCLIInProcess(unittest.TestCase):
 
         from s3lfs.path_resolver import PathResolver
 
-        # Mock git root and current directory
-        git_root = Path("/test/git/root")
+        # Mock git root and current directory; anchored so it is absolute
+        # on Windows too, where "/test/..." has no drive.
+        git_root = Path(Path.cwd().anchor, "test", "git", "root")
         path_resolver = PathResolver(git_root)
 
         # Test 1: When in a subdirectory, relative path should be resolved from CWD
-        cwd = Path("/test/git/root/subdir")
+        cwd = git_root / "subdir"
 
         # "file.txt" from subdir should resolve to "subdir/file.txt"
         result = path_resolver.from_cli_input("file.txt", cwd=cwd)
@@ -135,10 +136,11 @@ class TestS3LFSCLIInProcess(unittest.TestCase):
 
         from s3lfs.path_resolver import PathResolver
 
-        # Mock git root and current directory (like being in GoProProcessed subdirectory)
-        git_root = Path("/test/git/root")
+        # Mock git root and current directory (like being in GoProProcessed
+        # subdirectory); anchored so it is absolute on Windows too.
+        git_root = Path(Path.cwd().anchor, "test", "git", "root")
         path_resolver = PathResolver(git_root)
-        cwd = Path("/test/git/root/GoProProcessed")
+        cwd = git_root / "GoProProcessed"
 
         # When in GoProProcessed and user types "capture157",
         # it should resolve to "GoProProcessed/capture157"

--- a/tests/test_hook_behaviour.py
+++ b/tests/test_hook_behaviour.py
@@ -8,6 +8,11 @@ from pathlib import Path
 
 from s3lfs.cli import HOOK_SCRIPTS, _install_hook, _uninstall_hook
 
+# Hooks are shell scripts, so they run under sh everywhere -- on Windows
+# that is Git Bash's sh.exe, the same interpreter git itself uses for
+# hooks there. /bin/sh only exists on POSIX.
+SH = shutil.which("sh") or "/bin/sh"
+
 
 class TestHookExitStatus(unittest.TestCase):
     """The blocking hooks must abort their git operation when s3lfs fails.
@@ -44,14 +49,14 @@ class TestHookExitStatus(unittest.TestCase):
         script.write_text(f"#!/bin/sh\necho 'fake s3lfs ran'\nexit {exit_code}\n")
         script.chmod(0o755)
         env = dict(os.environ)
-        env["PATH"] = f"{self.bin_dir}:{env['PATH']}"
+        env["PATH"] = f"{self.bin_dir}{os.pathsep}{env['PATH']}"
         return env
 
     def _run_hook(self, hook_name, exit_code, args=(), stdin=""):
         env = self._fake_s3lfs(exit_code)
         hook_path = _install_hook(self.hooks_dir, hook_name, HOOK_SCRIPTS[hook_name])
         return subprocess.run(
-            ["/bin/sh", str(hook_path), *args],
+            [SH, str(hook_path), *args],
             capture_output=True,
             text=True,
             env=env,
@@ -126,6 +131,10 @@ class TestHookInstallAtomicity(unittest.TestCase):
         self.assertIn("user hook", content)
         self.assertIn("s3lfs", content)
 
+    @unittest.skipIf(
+        os.name == "nt",
+        "Windows has no POSIX exec bit; git-for-Windows runs hooks via sh",
+    )
     def test_installed_hook_is_executable(self):
         _install_hook(self.hooks_dir, "pre-push", HOOK_SCRIPTS["pre-push"])
         mode = (self.hooks_dir / "pre-push").stat().st_mode

--- a/tests/test_install_hooks.py
+++ b/tests/test_install_hooks.py
@@ -41,6 +41,10 @@ class TestInstallHookHelper(unittest.TestCase):
         self.assertTrue(content.startswith("#!/bin/sh\n"))
         self.assertIn("echo hello", content)
 
+    @unittest.skipIf(
+        os.name == "nt",
+        "Windows has no POSIX exec bit; git-for-Windows runs hooks via sh",
+    )
     def test_new_hook_is_executable(self):
         """Newly created hook file has executable permission."""
         block = f"{S3LFS_HOOK_START}\necho hello\n{S3LFS_HOOK_END}"
@@ -99,7 +103,9 @@ class TestInstallHookHelper(unittest.TestCase):
         )
         # And it really runs
         result = subprocess.run(
-            ["/bin/sh", str(hook_path)], capture_output=True, text=True
+            [shutil.which("sh") or "/bin/sh", str(hook_path)],
+            capture_output=True,
+            text=True,
         )
         self.assertIn("s3lfs", result.stdout)
 
@@ -209,9 +215,15 @@ class TestGetHooksDir(unittest.TestCase):
         custom_hooks = git_root / "custom-hooks"
         custom_hooks.mkdir()
 
-        # Initialize a real git repo so git config works
-        os.system("git init >/dev/null 2>&1")
-        os.system(f"git config core.hooksPath {custom_hooks}")
+        # Initialize a real git repo so git config works. subprocess, not
+        # os.system: ">/dev/null" hands cmd.exe a redirect to a path that
+        # does not exist on Windows, so git init never ran there.
+        subprocess.run(["git", "init"], capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "core.hooksPath", str(custom_hooks)],
+            capture_output=True,
+            check=True,
+        )
 
         hooks_dir = _get_hooks_dir(git_root)
         self.assertEqual(hooks_dir, custom_hooks)

--- a/tests/test_internal_path_exclusion.py
+++ b/tests/test_internal_path_exclusion.py
@@ -58,7 +58,7 @@ class TestInternalPathExclusion(unittest.TestCase):
             pass
 
         found = s3lfs._resolve_filesystem_paths(str(self.root))
-        names = sorted(str(Path(p).relative_to(self.root)) for p in found)
+        names = sorted(Path(p).relative_to(self.root).as_posix() for p in found)
 
         self.assertEqual(names, ["data/asset.bin"])
 

--- a/tests/test_path_resolver.py
+++ b/tests/test_path_resolver.py
@@ -87,9 +87,25 @@ class TestPathResolver(unittest.TestCase):
 
     def test_to_filesystem_path_rejects_absolute(self):
         """Test that absolute paths are rejected as manifest keys."""
+        # Anchored so it is genuinely absolute on every platform; a bare
+        # "/absolute/path" has no drive on Windows.
+        absolute = str(Path(Path.cwd().anchor, "absolute", "path"))
         with self.assertRaises(ValueError) as ctx:
-            self.resolver.to_filesystem_path("/absolute/path")
+            self.resolver.to_filesystem_path(absolute)
         self.assertIn("must be relative", str(ctx.exception))
+
+    def test_to_filesystem_path_rejects_rooted_driveless_key(self):
+        """ "/foo" is not absolute on Windows since Python 3.13, but pathlib
+        join still replaces the base with it, escaping the repository. The
+        containment check must catch what isabs() misses."""
+        with self.assertRaises(ValueError):
+            self.resolver.to_filesystem_path("/outside/repo")
+
+    def test_to_filesystem_path_rejects_embedded_escape(self):
+        """A leading-prefix check misses "sub/../../outside"."""
+        with self.assertRaises(ValueError) as ctx:
+            self.resolver.to_filesystem_path("subdir/../../outside")
+        self.assertIn("cannot escape", str(ctx.exception))
 
     def test_to_filesystem_path_rejects_escape(self):
         """Test that paths escaping git root are rejected."""
@@ -265,7 +281,9 @@ class TestPathResolver(unittest.TestCase):
         """Test string representation."""
         repr_str = repr(self.resolver)
         self.assertIn("PathResolver", repr_str)
-        self.assertIn(str(self.git_root), repr_str)
+        # The resolver stores the resolved root (Windows expands 8.3 short
+        # names, macOS expands /tmp), so compare against the resolved form.
+        self.assertIn(str(self.git_root.resolve()), repr_str)
 
 
 class TestPathResolverRealWorldScenarios(unittest.TestCase):


### PR DESCRIPTION
Closes #138.

The 18 residual Windows failures broke down into 16 POSIX assumptions in tests and, once pulled apart, **two real product bugs** the failing tests were masking:

- **Manifest keys could escape the repository root on Windows.** `to_filesystem_path` trusted `os.path.isabs`, but since Python 3.13 a rooted key like `/foo` is not "absolute" on Windows — and `WindowsPath("C:/repo") / "/foo"` *replaces* the base, resolving to `C:/foo`, outside the repo. Keys with embedded `..` (`sub/../../outside`) got past the prefix check on every platform. Manifest keys arrive with a clone, so this was a path-traversal hole, not just a portability nit. The resolved path is now verified to stay inside the repository (3 new tests).
- **Subdirectory context silently turned off under Windows 8.3 short paths.** `PathResolver` resolved an explicitly passed `cwd` but not the `Path.cwd()` default, so a shell in `C:\Users\RUNNER~1\...` never matched the resolved git root — `s3lfs track file.txt` from a subdirectory would target the wrong key.

Test/infra fixes: `sh` found via PATH (Git Bash on Windows — the same interpreter git itself uses for hooks there), `os.pathsep`, `subprocess.run` instead of `os.system` with `>/dev/null` (which meant **`test_respects_core_hookspath` never actually created a repo on Windows**), drive-anchored fixtures, `as_posix()` comparisons, and exec-bit assertions skipped on a platform that has no exec bit.

`windows-latest` (Python 3.13) joins the CI matrix so it stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)