### PR TITLE
Release 0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.6.3] - 2026-08-09
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "s3lfs"
-version = "0.6.2"
+version = "0.6.3"
 description = "A Python-based version control system for large assets using Amazon S3."
 authors = [{name = "Kevin Blackburn-Matzen", email = "kmatzen@gmail.com"}]
 license = {text = "MIT"}


### PR DESCRIPTION
Version bump (0.6.2 was released earlier today). Contents: the manifest-key path-traversal fix and short-path subdirectory fix, plus Windows in the CI matrix (#143).

🤖 Generated with [Claude Code](https://claude.com/claude-code)